### PR TITLE
Pin @material-ui/utils version to 5.0.0-alpha.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/pickers": "^3.2.10",
+    "@material-ui/utils": "=5.0.0-alpha.27",
     "@sentry/react": "^5.26.0",
     "@svgr/webpack": "^4.3.3",
     "@uppy/core": "^1.9.0",


### PR DESCRIPTION
When running npm install:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! Found: react@16.14.0
npm ERR! node_modules/react
npm ERR!   react@"^16.8.6" from the root project
npm ERR!   peer react@">=16.3.0" from @emotion/core@10.1.1
npm ERR!   node_modules/@emotion/core
npm ERR!     dev @emotion/core@"^10.0.14" from the root project
npm ERR!     peer @emotion/core@"^10.0.27" from @emotion/styled@10.0.27
npm ERR!     node_modules/@emotion/styled
npm ERR!       dev @emotion/styled@"^10.0.14" from the root project
npm ERR!     2 more (emotion-theming, @emotion/styled-base)
npm ERR!   26 more (@emotion/styled, @flatfile/react, react-dom, ...)
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^17.0.0" from @material-ui/utils@5.0.0-alpha.28
npm ERR! node_modules/@material-ui/data-grid/node_modules/@material-ui/utils
npm ERR!   @material-ui/utils@"^5.0.0-alpha.14" from @material-ui/data-grid@4.0.0-alpha.23
npm ERR!   node_modules/@material-ui/data-grid
npm ERR!     @material-ui/data-grid@"^4.0.0-alpha.9" from the root project
```

This is because @material-ui/utils latest version (5.0.0-alpha.28) only
supports react "^17.0.0".  But 5.0.0-alpha.27 supports react
"^16.8.0 || ^17.0.0".

It's not possible to upgrade react to "17.0.0" because the latest version
(0.3.3) of @flatfile/react only supports react "^16.13.1".

https://github.com/FlatFilers/react-adapter/blob/d439037d3033b6ca34efff88f76572c290f52f1d/package.json