### PR TITLE
Add src/constants/apiKeysTemplate.js back

### DIFF
--- a/src/constants/apiKeysTemplate.js
+++ b/src/constants/apiKeysTemplate.js
@@ -1,0 +1,8 @@
+/* To successfully run the app, you need to recreate a .gitignore'd file
+in this directory, apiKeys.js */
+
+export const googleMapsApiKey = '';
+
+export const sentryDsn = '';
+
+export const flatfileKey = '';


### PR DESCRIPTION
`apiKeysTemplate.js` was removed in commit
"DEX-337 create AlertWrapper component" (86226532) and it was probably a
mistake (not explained in commit message).  Add the file back because it
is necessary for the build.