### PR TITLE
Add github workflow to update houston _frontend submodule

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -1,0 +1,27 @@
+name: Update submodule
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  update-submodule:
+    name: Update Houston's submodule to latest develop
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'WildMeOrg/houston'
+          submodules: true
+          token: ${{ secrets.PAT_TOKEN }}
+      - run: |
+          bash -xe <<EOF
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          cd _frontend
+          git reset --hard origin/develop
+          cd ..
+          git commit -am 'Update _frontend to latest develop'
+          git show
+          git push origin HEAD
+          EOF


### PR DESCRIPTION
The github action should run every time develop is updated and updates the `_frontend` submodule in houston to the latest develop of codex-frontend.

A [PAT token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) needs to be generated with "repo" permissions and then added as a repository secret "PAT_TOKEN" on codex-frontend "settings" -> "secrets" page.

I tried this workflow in my forked repo and it created this [commit](https://github.com/WildMeOrg/houston/commit/3f2f2e0016471930d066b48c5a3329138cdd6049):

```diff
commit 3f2f2e0016471930d066b48c5a3329138cdd6049 (origin/update-frontend)
Author: github-actions <github-actions@github.com>
Date:   Wed Sep 1 21:18:36 2021 +0000

    Update _frontend to latest develop

diff --git a/_frontend b/_frontend
index 5c24bda7..09fe111a 160000
--- a/_frontend
+++ b/_frontend
@@ -1 +1 @@
-Subproject commit 5c24bda7b87e42c4f0a7566496893e9cd45a8455
+Subproject commit 09fe111aa4a9457de55a7e9e0a9c9ac5ae615afe
```