### PR TITLE
Fix houston update workflow

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -18,10 +18,10 @@ jobs:
           bash -xe <<EOF
           git config user.name github-actions
           git config user.email github-actions@github.com
-          cd _frontend
+          cd _frontend.codex
           git reset --hard origin/develop
           cd ..
-          git commit -am 'Update _frontend to latest develop'
+          git commit -am 'Update _frontend.codex submodule to HEAD of codex-frontend@develop'
           git show
           git push origin HEAD
           EOF


### PR DESCRIPTION
The submodule path was changed from `_frontend` to `_frontend.codex`
late in Oct 2021. This change fixes the workflow so that the houston
submodule is kept in sync with the tip of `codex-frontend@develop`.