### PR TITLE
Show initial value in latlng input

### DIFF
--- a/src/components/fields/edit/LatLongEditor.jsx
+++ b/src/components/fields/edit/LatLongEditor.jsx
@@ -55,13 +55,15 @@ export default function LatLongEditor({
 
   useEffect(
     () => {
-      const {
-        latitudeString,
-        longitudeString,
-      } = deriveGpsStringsFromValue(savedMapLatLng);
+      if (savedMapLatLng) {
+        const {
+          latitudeString,
+          longitudeString,
+        } = deriveGpsStringsFromValue(savedMapLatLng);
 
-      setCurrentLatitudeString(latitudeString);
-      setCurrentLongitudeString(longitudeString);
+        setCurrentLatitudeString(latitudeString);
+        setCurrentLongitudeString(longitudeString);
+      }
     },
     [get(savedMapLatLng, '0'), get(savedMapLatLng, '1')],
   );


### PR DESCRIPTION
Fixes a bug where LatLng input would not show its initial value