### PR TITLE
Fix region editor

### DIFF
--- a/src/pages/fieldManagement/settings/defaultFieldComponents/Editors.jsx
+++ b/src/pages/fieldManagement/settings/defaultFieldComponents/Editors.jsx
@@ -4,9 +4,9 @@ import { get } from 'lodash-es';
 import TreeEditor from './TreeEditor';
 import ConfigureDefaultField from './ConfigureDefaultField';
 
-export var RelationshipEditor = function() {
+export function RelationshipEditor() {
   return null;
-};
+}
 
 // export function RelationshipEditor({
 //   onClose,
@@ -38,7 +38,7 @@ export var RelationshipEditor = function() {
 //   );
 // }
 
-export var RegionEditor = function({
+export function RegionEditor({
   onClose,
   onSubmit,
   formSettings,
@@ -68,4 +68,4 @@ export var RegionEditor = function({
       {children}
     </ConfigureDefaultField>
   );
-};
+}

--- a/src/pages/fieldManagement/settings/defaultFieldComponents/TreeEditor.jsx
+++ b/src/pages/fieldManagement/settings/defaultFieldComponents/TreeEditor.jsx
@@ -119,6 +119,7 @@ export default function TreeEditor({
   schema,
   value,
   onChange,
+  siteSettings, // unpacking to prevent passing to div
   ...rest
 }) {
   return (


### PR DESCRIPTION
Fixes a couple of bugs:
 - Selecting a subregion was throwing an error on the report form page (`cannot read property "id" of undefined`)
 - Dropdown options were changing after selecting a region 
 
Added an optimization so that choices are not recursively collapsed every render
