### PR TITLE
Display version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,7 @@ package-lock.json
 .vscode/
 
 /src/constants/apiKeys.js
+#: created on build
+/src/constants/version.js
 
 dist.*.tar.gz

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "react-player": "^2.4.0",
     "react-query": "^3.34.1",
     "react-transition-group": "^4.4.1",
-    "uuid": "^3.4.0"
+    "uuid": "^3.4.0",
+    "webpack-version-file": "^0.1.6"
   }
 }

--- a/src/pages/serverStatus/ServerStatus.jsx
+++ b/src/pages/serverStatus/ServerStatus.jsx
@@ -8,6 +8,7 @@ import Skeleton from '@material-ui/lab/Skeleton';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
 
+import version from '../../constants/version';
 import useGetSiteInfo from '../../models/site/useGetSiteInfo';
 import useDocumentTitle from '../../hooks/useDocumentTitle';
 import useServerStatus from '../../models/server/useServerStatus';
@@ -114,6 +115,7 @@ export default function ServerStatus() {
           </>
         ) : (
           <>
+            <Text>{`Frontend version: ${version.scmVersion}`}</Text>
             <Text>
               {`Houston version: ${get(
                 siteInfo,
@@ -148,6 +150,7 @@ export default function ServerStatus() {
           </>
         ) : (
           <>
+            <Text>{`Frontend commit: ${version.commitHash}`}</Text>
             <Text>
               {`Houston git hash: ${get(
                 siteInfo,


### PR DESCRIPTION
<img width="662" alt="Screen Shot 2022-02-18 at 11 37 01" src="https://user-images.githubusercontent.com/168470/154752033-fa66b49e-11b9-4d73-ae7e-ab8893885a69.png">

For Houston integration this depends on https://github.com/WildMeOrg/houston/pull/506 It will need merged before this gets merged.

In the example screenshot, the version and commit are the same. Once we've created a tag for this repo it will display something like `<tag>[-<commit-distance>-g<hash>[-dirty]]`. For example, `v1.2.3-14-g0bc163f-dirty` where `v1.2.3` was the latest tag, there are `14` commits since the last tag, current hash is `0bc163f`, and there are currently uncommitted files in the repo indicated by `-dirty`. 