### PR TITLE
Dex 663 qa feedback and DEX-808

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -983,5 +983,6 @@
   "INDIVIDUAL_MERGE_COMPLETE_TITLE": "Individual merge completed",
   "PHOTOS_OF": "Photos of {name}",
   "MARK_AS_READ": "Mark as read",
-  "DONE": "Done"
+  "DONE": "Done",
+  "VIEW_ALL_NOTIFICATIONS_MORE_DETAIL": "View all notifications in more detail"
 }

--- a/src/components/AuthenticatedAppHeader/index.js
+++ b/src/components/AuthenticatedAppHeader/index.js
@@ -31,6 +31,8 @@ export default function AppHeader() {
     loading: notificationsLoading,
     refresh: refreshNotifications,
   } = useNotifications();
+  console.log('deleteMe notifications are: ');
+  console.log(notifications);
   const notificationsCount = get(notifications, 'length', 0);
 
   const isSm = useMediaQuery(theme.breakpoints.down('sm'));

--- a/src/components/AuthenticatedAppHeader/index.js
+++ b/src/components/AuthenticatedAppHeader/index.js
@@ -32,8 +32,6 @@ export default function AppHeader() {
     data: notifications,
     loading: notificationsLoading,
   } = useNotifications();
-  console.log('deleteMe notifications are: ');
-  console.log(notifications);
   const queryClient = useQueryClient();
   const refreshNotifications = () => {
     queryClient.invalidateQueries(queryKeys.allNotifications);
@@ -44,6 +42,10 @@ export default function AppHeader() {
   const isSm = useMediaQuery(theme.breakpoints.down('sm'));
 
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [
+    shouldOpenNotificationPane,
+    setShouldOpenNotificationPane,
+  ] = useState(false);
   const [exploreOpen, setExploreOpen] = React.useState(false);
   const [userMenuAnchorEl, setUserMenuAnchorEl] = React.useState(
     null,
@@ -130,8 +132,11 @@ export default function AppHeader() {
             Icon={NotificationsIcon}
             titleId="NOTIFICATIONS"
             showBadge={Boolean(notificationsCount)}
-            badgeContent={notificationsCount}
-            onClick={e => setNotificationsAnchorEl(e.currentTarget)}
+            badgeContent={notificationsCount} // onClick={e => setNotificationsAnchorEl(e.currentTarget)}
+            onClick={e => {
+              setNotificationsAnchorEl(e.currentTarget);
+              setShouldOpenNotificationPane(true);
+            }}
             style={{ position: 'relative' }}
           />
           <NotificationsPane
@@ -139,7 +144,9 @@ export default function AppHeader() {
             setAnchorEl={setNotificationsAnchorEl}
             notifications={notifications || []}
             notificationsLoading={notificationsLoading}
-            refreshNotifications={refreshNotifications}
+            refreshNotifications={refreshNotifications} // onClick={() => setShouldOpenNotificationPane(true)}
+            shouldOpen={shouldOpenNotificationPane}
+            setShouldOpen={setShouldOpenNotificationPane}
           />
           <HeaderButton
             onClick={e => setUserMenuAnchorEl(e.currentTarget)}

--- a/src/components/AuthenticatedAppHeader/index.js
+++ b/src/components/AuthenticatedAppHeader/index.js
@@ -132,7 +132,7 @@ export default function AppHeader() {
             Icon={NotificationsIcon}
             titleId="NOTIFICATIONS"
             showBadge={Boolean(notificationsCount)}
-            badgeContent={notificationsCount} // onClick={e => setNotificationsAnchorEl(e.currentTarget)}
+            badgeContent={notificationsCount}
             onClick={e => {
               setNotificationsAnchorEl(e.currentTarget);
               setShouldOpenNotificationPane(true);
@@ -144,7 +144,7 @@ export default function AppHeader() {
             setAnchorEl={setNotificationsAnchorEl}
             notifications={notifications || []}
             notificationsLoading={notificationsLoading}
-            refreshNotifications={refreshNotifications} // onClick={() => setShouldOpenNotificationPane(true)}
+            refreshNotifications={refreshNotifications}
             shouldOpen={shouldOpenNotificationPane}
             setShouldOpen={setShouldOpenNotificationPane}
           />

--- a/src/components/dialogs/NotificationDetailsDialog.jsx
+++ b/src/components/dialogs/NotificationDetailsDialog.jsx
@@ -32,14 +32,12 @@ export default function NotificationDetailsDialog({
     'Unnamed User',
   );
   if (user1Name === '') user1Name = 'Unnamed User';
-  console.log('deleteMe user1Name is: ' + user1Name);
   let user2Name = get(
     notification,
     ['message_values', 'user2_name'],
     'Unnamed User',
   );
   if (user2Name === '') user2Name = 'Unnamed User';
-  console.log('deleteMe user2Name is: ' + user2Name);
   const individual1Names = notification?.names || []; // TODO flesh out more once this is included in notifications DEX-739
   const individual1NicknameObject = individual1Names.find(
     n => n.context === 'nickname',

--- a/src/components/dialogs/NotificationDetailsDialog.jsx
+++ b/src/components/dialogs/NotificationDetailsDialog.jsx
@@ -26,14 +26,20 @@ export default function NotificationDetailsDialog({
   };
 
   const senderName = get(notification, 'sender_name', 'Unnamed User');
-  const user1Name = get(notification, [
-    'message_values',
-    'user1_name',
-  ]);
-  const user2Name = get(notification, [
-    'message_values',
-    'user2_name',
-  ]);
+  let user1Name = get(
+    notification,
+    ['message_values', 'user1_name'],
+    'Unnamed User',
+  );
+  if (user1Name === '') user1Name = 'Unnamed User';
+  console.log('deleteMe user1Name is: ' + user1Name);
+  let user2Name = get(
+    notification,
+    ['message_values', 'user2_name'],
+    'Unnamed User',
+  );
+  if (user2Name === '') user2Name = 'Unnamed User';
+  console.log('deleteMe user2Name is: ' + user2Name);
   const individual1Names = notification?.names || []; // TODO flesh out more once this is included in notifications DEX-739
   const individual1NicknameObject = individual1Names.find(
     n => n.context === 'nickname',

--- a/src/components/dialogs/NotificationDetailsDialog.jsx
+++ b/src/components/dialogs/NotificationDetailsDialog.jsx
@@ -9,6 +9,7 @@ import StandardDialog from '../StandardDialog';
 import Text from '../Text';
 import Button from '../Button';
 import CustomAlert from '../Alert';
+import { getNotificationProps } from '../../utils/notificationUtils';
 
 export default function NotificationDetailsDialog({
   open,
@@ -25,31 +26,13 @@ export default function NotificationDetailsDialog({
     onClose();
   };
 
-  const senderName = get(notification, 'sender_name', 'Unnamed User');
-  let user1Name = get(
-    notification,
-    ['message_values', 'user1_name'],
-    'Unnamed User',
-  );
-  if (user1Name === '') user1Name = 'Unnamed User';
-  let user2Name = get(
-    notification,
-    ['message_values', 'user2_name'],
-    'Unnamed User',
-  );
-  if (user2Name === '') user2Name = 'Unnamed User';
-  const individual1Names = notification?.names || []; // TODO flesh out more once this is included in notifications DEX-739
-  const individual1NicknameObject = individual1Names.find(
-    n => n.context === 'nickname',
-  );
-  const individual1Nickname =
-    individual1NicknameObject?.value || 'Unnamed individual';
-  const individual2Names = notification?.names || []; // TODO flesh out more once this is included in notifications DEX-739
-  const individual2NicknameObject = individual2Names.find(
-    n => n.context === 'nickname',
-  );
-  const individual2Nickname =
-    individual2NicknameObject?.value || 'Unnamed individual';
+  const {
+    senderName,
+    user1Name,
+    user2Name,
+    individual1Nickname,
+    individual2Nickname,
+  } = getNotificationProps(notification);
 
   return (
     <StandardDialog

--- a/src/constants/notificationSchema.js
+++ b/src/constants/notificationSchema.js
@@ -19,6 +19,8 @@ notificationSchemaPlaceholder[
   notificationMessage: 'A_COLLABORATION_WAS_CREATED_ON_YOUR_BEHALF',
   moreDetailedDescription:
     'A_COLLABORATION_WAS_CREATED_ON_YOUR_BEHALF_MORE_DETAILED',
+  showNotificationDialog: false,
+  buttonPath: '/',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_request
@@ -26,7 +28,7 @@ notificationSchemaPlaceholder[
   titleId: 'COLLABORATION_REQUEST',
   notificationMessage: 'COLLABORATION_VIEW_REQUEST_BRIEF',
   moreDetailedDescription: 'COLLABORATION_VIEW_REQUEST_DESCRIPTION',
-  viewInNotificationPane: true,
+  showNotificationDialog: true,
   path: '/view_permission',
 };
 notificationSchemaPlaceholder[
@@ -35,7 +37,7 @@ notificationSchemaPlaceholder[
   titleId: 'COLLABORATION_APPROVED_TITLE',
   notificationMessage: 'COLLABORATION_APPROVED',
   moreDetailedDescription: 'COLLABORATION_APPROVED',
-  viewInNotificationPane: false,
+  showNotificationDialog: false,
   path: '/view_permission',
 };
 notificationSchemaPlaceholder[
@@ -44,7 +46,7 @@ notificationSchemaPlaceholder[
   titleId: 'COLLABORATION_REVOKE_TITLE',
   notificationMessage: 'COLLABORATION_REVOKE_BRIEF',
   moreDetailedDescription: 'COLLABORATION_REVOKE_BRIEF',
-  viewInNotificationPane: false,
+  showNotificationDialog: false,
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_edit_request
@@ -52,7 +54,7 @@ notificationSchemaPlaceholder[
   titleId: 'COLLABORATION_EDIT_REQUEST_TITLE',
   notificationMessage: 'COLLABORATION_EDIT_REQUEST_BRIEF',
   moreDetailedDescription: 'COLLABORATION_EDIT_REQUEST_DESCRIPTION',
-  viewInNotificationPane: true,
+  showNotificationDialog: true,
   path: '/edit_permission',
 };
 notificationSchemaPlaceholder[
@@ -61,7 +63,7 @@ notificationSchemaPlaceholder[
   titleId: 'COLLABORATION_EDIT_APPROVED_TITLE',
   notificationMessage: 'EDIT_COLLABORATION_APPROVED',
   moreDetailedDescription: 'EDIT_COLLABORATION_APPROVED',
-  viewInNotificationPane: false,
+  showNotificationDialog: false,
   path: '/edit_permission',
 };
 notificationSchemaPlaceholder[
@@ -70,7 +72,8 @@ notificationSchemaPlaceholder[
   titleId: 'COLLABORATION_EDIT_REVOKE_TITLE',
   notificationMessage: 'EDIT_COLLABORATION_REVOKED',
   moreDetailedDescription: 'EDIT_COLLABORATION_REVOKED',
-  viewInNotificationPane: false,
+  showNotificationDialog: false,
+  buttonPath: '/',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_manager_revoke
@@ -78,7 +81,8 @@ notificationSchemaPlaceholder[
   titleId: 'COLLABORATION_MANAGER_REVOKE_TITLE',
   notificationMessage: 'COLLABORATION_REVOKED_BY_MANAGER',
   moreDetailedDescription: 'COLLABORATION_REVOKED_BY_MANAGER',
-  viewInNotificationPane: false,
+  showNotificationDialog: false,
+  buttonPath: '/',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.individual_merge_request
@@ -86,7 +90,7 @@ notificationSchemaPlaceholder[
   titleId: 'INDIVIDUAL_MERGE_REQUEST_TITLE',
   notificationMessage: 'INDIVIDUAL_MERGE_REQUEST_MESSAGE',
   moreDetailedDescription: 'INDIVIDUAL_MERGE_REQUEST_MESSAGE',
-  viewInNotificationPane: true,
+  showNotificationDialog: true,
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.individual_merge_complete
@@ -94,6 +98,7 @@ notificationSchemaPlaceholder[
   titleId: 'INDIVIDUAL_MERGE_COMPLETE_TITLE',
   notificationMessage: 'INDIVIDUALS_MERGE_COMPLETE_MESSAGE',
   moreDetailedDescription: 'INDIVIDUALS_MERGE_COMPLETE_MESSAGE',
-  viewInNotificationPane: false,
+  showNotificationDialog: false,
+  buttonPath: '/individuals/', // TODO figure out how to pass individual ID to this
 };
 export const notificationSchema = notificationSchemaPlaceholder;

--- a/src/models/notification/usePatchNotification.js
+++ b/src/models/notification/usePatchNotification.js
@@ -1,43 +1,9 @@
-// import { useState } from 'react';
-// import axios from 'axios';
-// import { get } from 'lodash-es';
-// import { formatError } from '../../utils/formatters';
+import { useState } from 'react';
+import axios from 'axios';
+import { get } from 'lodash-es';
+import { formatError } from '../../utils/formatters';
 
-// import queryKeys from '../../constants/queryKeys';
-import { getNotificationQueryKey } from '../../constants/queryKeys';
-import { usePatch } from '../../hooks/useMutate';
-
-export default function usePatchNotification(notificationId) {
-  const markRead = async notificationId => {
-    const result = await patchNotification(notificationId, [
-    {
-      op: 'replace',
-      path: '/is_read',
-      value: true,
-    },
-    ]);
-
-    return result;
-  //   return usePatch({
-  //     url: `/notifications/${notificationId}`,
-  //     data: [
-  //       {
-  //         op: 'replace',
-  //         path: '/is_read',
-  //         value: true,
-  //       },
-  //     ],
-  //   });
-  // };
-  // const usePatchNotification = usePatch({
-  //   url: `/notifications/${notificationId}`,
-  //   queryKey: getNotificationQueryKey(notificationId),
-  // });
-  // return { usePatchNotification, markRead };
-  return usePatch({
-    url: `/notifications/${notificationId}`,
-    queryKey: getNotificationQueryKey(notificationId),
-  });
+export default function usePatchNotification() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
@@ -72,6 +38,7 @@ export default function usePatchNotification(notificationId) {
   };
 
   const markRead = async notificationId => {
+    setLoading(true);
     const result = await patchNotification(notificationId, [
       {
         op: 'replace',
@@ -79,7 +46,7 @@ export default function usePatchNotification(notificationId) {
         value: true,
       },
     ]);
-
+    setLoading(false);
     return result;
   };
 

--- a/src/pages/assetGroup/AssetGroup.jsx
+++ b/src/pages/assetGroup/AssetGroup.jsx
@@ -23,8 +23,8 @@ import AGSTable from './AGSTable';
 export default function AssetGroup() {
   const { id } = useParams();
   const history = useHistory();
-  const intl = useIntl();
   const queryClient = useQueryClient();
+  const intl = useIntl();
 
   const { data, loading, error, statusCode } = useAssetGroup(id);
 

--- a/src/pages/notifications/Notifications.jsx
+++ b/src/pages/notifications/Notifications.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
 import { get } from 'lodash-es';
+import { useQueryClient } from 'react-query';
 
 import { useTheme } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
@@ -22,17 +23,18 @@ import usePatchNotification from '../../models/notification/usePatchNotification
 import { calculatePrettyTimeElapsedSince } from '../../utils/formatters';
 import { notificationSchema } from '../../constants/notificationSchema';
 import { notificationTypes } from '../../components/dialogs/notificationDialogUtils';
+import queryKeys from '../../constants/queryKeys';
 
 export default function Notifications() {
   const intl = useIntl();
   const theme = useTheme();
+  const queryClient = useQueryClient();
 
   useDocumentTitle('NOTIFICATIONS');
 
   const {
     data: notifications,
     loading: notificationsLoading,
-    refresh: refreshNotifications,
   } = useNotifications(true);
 
   const { markRead } = usePatchNotification();
@@ -171,7 +173,12 @@ export default function Notifications() {
                         dialog: notificationDialog,
                       });
                       await markRead(get(notification, 'guid'));
-                      refreshNotifications();
+                      queryClient.invalidateQueries(
+                        queryKeys.allNotifications,
+                      );
+                      queryClient.invalidateQueries(
+                        queryKeys.unreadNotifications,
+                      );
                     }}
                     style={{ cursor: 'pointer' }}
                   >

--- a/src/pages/notifications/Notifications.jsx
+++ b/src/pages/notifications/Notifications.jsx
@@ -24,6 +24,7 @@ import { calculatePrettyTimeElapsedSince } from '../../utils/formatters';
 import { notificationSchema } from '../../constants/notificationSchema';
 import { notificationTypes } from '../../components/dialogs/notificationDialogUtils';
 import queryKeys from '../../constants/queryKeys';
+import { getNotificationProps } from '../../utils/notificationUtils';
 
 export default function Notifications() {
   const intl = useIntl();
@@ -86,35 +87,13 @@ export default function Notifications() {
                   notificationType,
                 );
                 const read = get(notification, 'is_read', false);
-                const senderName = get(
-                  notification,
-                  'sender_name',
-                  'Unnamed User',
-                );
-                const user1Name = get(
-                  notification,
-                  ['message_values', 'user1_name'],
-                  'Unnamed User',
-                );
-                const user2Name = get(
-                  notification,
-                  ['message_values', 'user2_name'],
-                  'Unnamed User',
-                );
-                const individual1Names = notification?.names || []; // TODO flesh out more once this is included in notifications DEX-739
-                const individual1NicknameObject = individual1Names.find(
-                  n => n.context === 'nickname',
-                );
-                const individual1Nickname =
-                  individual1NicknameObject?.value ||
-                  'Unnamed individual';
-                const individual2Names = notification?.names || []; // TODO flesh out more once this is included in notifications DEX-739
-                const individual2NicknameObject = individual2Names.find(
-                  n => n.context === 'nickname',
-                );
-                const individual2Nickname =
-                  individual2NicknameObject?.value ||
-                  'Unnamed individual';
+                const {
+                  senderName,
+                  user1Name,
+                  user2Name,
+                  individual1Nickname,
+                  individual2Nickname,
+                } = getNotificationProps(notification);
                 const createdDate = notification?.created;
                 const timeSince = calculatePrettyTimeElapsedSince(
                   createdDate,

--- a/src/pages/notifications/Notifications.jsx
+++ b/src/pages/notifications/Notifications.jsx
@@ -89,14 +89,16 @@ export default function Notifications() {
                   'sender_name',
                   'Unnamed User',
                 );
-                const user1Name = get(notification, [
-                  'message_values',
-                  'user1_name',
-                ]);
-                const user2Name = get(notification, [
-                  'message_values',
-                  'user2_name',
-                ]);
+                const user1Name = get(
+                  notification,
+                  ['message_values', 'user1_name'],
+                  'Unnamed User',
+                );
+                const user2Name = get(
+                  notification,
+                  ['message_values', 'user2_name'],
+                  'Unnamed User',
+                );
                 const individual1Names = notification?.names || []; // TODO flesh out more once this is included in notifications DEX-739
                 const individual1NicknameObject = individual1Names.find(
                   n => n.context === 'nickname',

--- a/src/utils/notificationUtils.js
+++ b/src/utils/notificationUtils.js
@@ -1,0 +1,26 @@
+export const getNotificationProps = notification => {
+  const senderName = notification?.sender_name || 'Unnamed User';
+  const user1Name =
+    notification?.message_values?.user1_name || 'Unnamed User';
+  const user2Name =
+    notification?.message_values?.user2_name || 'Unnamed User';
+  const individual1Names = notification?.names || []; // TODO flesh out more once this is included in notifications DEX-739
+  const individual1NicknameObject = individual1Names.find(
+    n => n.context === 'nickname',
+  );
+  const individual1Nickname =
+    individual1NicknameObject?.value || 'Unnamed individual';
+  const individual2Names = notification?.names || []; // TODO flesh out more once this is included in notifications DEX-739
+  const individual2NicknameObject = individual2Names.find(
+    n => n.context === 'nickname',
+  );
+  const individual2Nickname =
+    individual2NicknameObject?.value || 'Unnamed individual';
+  return {
+    senderName,
+    user1Name,
+    user2Name,
+    individual1Nickname,
+    individual2Nickname,
+  };
+};


### PR DESCRIPTION
Responds to all of JH's QA feedback from https://wildme.atlassian.net/browse/DEX-663:

> In the Notifications modal, clicking “Mark as Read” can cause notifications to disappear or change their button to a grayed out DONE.

Per discussions with Ben, all notifications have a view button, but some of these view buttons navigate the user to their home page, while others pull up a dialog with actions.

> "Mark as Read” button can change size depending on length of text next to it:

In the process of troubleshooting this, I kind of accidentally added a <div> around the button. This coincidentally seems to force a standardization of button size. If someone who understands css better than me know why this happened, I would be eager to know that.

> In “View All Notifications”, clicking on an entry does not then turn it gray to show it has been read. Seems to be persisting on the backend correctly though as a refresh then shows the read entry as gray. 

The refreshNotifications() method originally being called was something that we recently deprecated from the useNotification (and other useGet-based) hooks. It now actually refreshes by invalidating query keys.

> User Manager-revoked collaboration falsely tells both affected users that the other user hates them and revoked the collaborations. Should say that the collaboration was revoked by the User Manager like it does when the collab is created by the user manager.

This is a back end bug. I created a ticket for them, and a separate FE ticket for me to follow up on, thereby decoupling this issue from the current ticket.

Note that I also went ahead and tackled https://wildme.atlassian.net/browse/DEX-808 in this PR.
The issue here was that the little popover window or whatever it's called was using the xAnchor point both as its `open` boolean and as its anchor point. When someone dismissed it, it was setting the xAnchor point to null, which I guess was generously being interpreted as 0 on the x-axis. I resolved this by decoupling the xAnchor from the thing that controls `open`.