### PR TITLE
DEX-811 missing "report sighting success" page

### DIFF
--- a/src/AuthenticatedSwitch.jsx
+++ b/src/AuthenticatedSwitch.jsx
@@ -23,7 +23,6 @@ import Users from './pages/user/Users';
 import BulkImport from './pages/bulkImport/BulkImport';
 import BulkImportSuccess from './pages/bulkImport/Success';
 import ReportSighting from './pages/reportSighting/ReportSighting';
-import ReportSuccess from './pages/reportSighting/Success';
 import Notifications from './pages/notifications/Notifications';
 import FourOhFour from './pages/fourohfour/FourOhFour';
 import useSiteSettings from './models/site/useSiteSettings';
@@ -145,9 +144,6 @@ export default function AuthenticatedSwitch() {
                       </Route>
                       <Route path="/bulk-import">
                         <BulkImport />
-                      </Route>
-                      <Route path="/report/success/:id">
-                        <ReportSuccess authenticated />
                       </Route>
                       <Route path="/report">
                         <ReportSighting authenticated />

--- a/src/UnauthenticatedSwitch.jsx
+++ b/src/UnauthenticatedSwitch.jsx
@@ -49,7 +49,7 @@ export default function UnauthenticatedSwitch() {
                   }}
                 >
                   <Switch location={location}>
-                    <Route path="/report/success/:id">
+                    <Route path="/report/success">
                       <ReportSuccess />
                     </Route>
                     <Route path="/report">

--- a/src/pages/reportSighting/ReportForm.jsx
+++ b/src/pages/reportSighting/ReportForm.jsx
@@ -337,9 +337,10 @@ export default function ReportForm({
                   'guid',
                 ]);
                 if (assetGroupSightingId) {
-                  history.push(
-                    `/pending-sightings/${assetGroupSightingId}`,
-                  );
+                  const relativeUrl = authenticated
+                    ? `/pending-sightings/${assetGroupSightingId}`
+                    : '/report/success/';
+                  history.push(relativeUrl);
                 }
               }
             }}

--- a/src/pages/reportSighting/Success.jsx
+++ b/src/pages/reportSighting/Success.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import { useTheme } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 
@@ -9,10 +8,9 @@ import ButtonLink from '../../components/ButtonLink';
 import Text from '../../components/Text';
 import BaoHappy from '../../components/svg/BaoHappy';
 
-export default function ReportSuccess({ authenticated }) {
+export default function ReportSuccess() {
   const theme = useTheme();
   const themeColor = theme.palette.primary.main;
-  const { id } = useParams();
   useDocumentTitle('REPORT_SUCCESS_TITLE');
 
   return (
@@ -44,24 +42,12 @@ export default function ReportSuccess({ authenticated }) {
         direction="column"
         style={{ padding: 16, maxWidth: 340 }}
       >
-        {authenticated && (
-          <Grid item style={{ position: 'relative' }}>
-            <ButtonLink
-              style={{
-                width: '100%',
-              }}
-              display="primary"
-              href={`/sightings/${id}`}
-              id="VIEW_SIGHTING"
-            />
-          </Grid>
-        )}
         <Grid item style={{ position: 'relative' }}>
           <ButtonLink
             style={{
               width: '100%',
             }}
-            display={authenticated ? 'secondary' : 'primary'}
+            display="primary"
             href="/report"
             id="REPORT_ANOTHER_SIGHTING"
           />
@@ -69,7 +55,7 @@ export default function ReportSuccess({ authenticated }) {
         <Grid item style={{ position: 'relative' }}>
           <ButtonLink
             style={{ width: '100%' }}
-            display={authenticated ? 'tertiary' : 'secondary'}
+            display="secondary"
             href="/"
             id="RETURN_HOME"
           />


### PR DESCRIPTION
- After successfully POSTing a sighting, an unauthenticated user is redirected to `/report/success` rather than to the pending sighting page that they are not authorized to see.
- Because only unauthorized users see the Success page, I removed it from the AuthenticatedSwitch, and removed the authorization conditions within the Success component.