### PR TITLE
DEX-847 remain on tab after committing AGS

### DIFF
--- a/src/pages/sighting/AssetGroupSighting.jsx
+++ b/src/pages/sighting/AssetGroupSighting.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams, useHistory, useLocation } from 'react-router-dom';
 
 import SightingCore from './SightingCore';
 import useGetAGS from '../../models/assetGroupSighting/useGetAGS';
@@ -7,6 +7,7 @@ import useGetAGS from '../../models/assetGroupSighting/useGetAGS';
 export default function AssetGroupSighting() {
   const history = useHistory();
   const { id } = useParams();
+  const { hash } = useLocation();
 
   const {
     data: assetGroupSightingData,
@@ -20,7 +21,7 @@ export default function AssetGroupSighting() {
   useEffect(
     () => {
       if (sightingId) {
-        history.push(`/sightings/${sightingId}`);
+        history.push(`/sightings/${sightingId}${hash}`);
       }
     },
     [sightingId],


### PR DESCRIPTION
- Adds the current hash to the redirect URL after a successful AGS commit so that the user stays on the same tab they were on when they committed the AGS.