### PR TITLE
update individual search API endpoints

### DIFF
--- a/src/models/individual/useFilterIndividuals.js
+++ b/src/models/individual/useFilterIndividuals.js
@@ -54,7 +54,7 @@ export default function useFilterIndividuals(
           );
 
           const rawResponse = await axios.request({
-            url: `${__houston_url__}/api/v1/search/individuals`,
+            url: `${__houston_url__}/api/v1/search/proxy/individuals`,
             method: 'post',
             data: {
               from: pageIndex * resultsPerPage,

--- a/src/models/individual/useQueryIndividuals.js
+++ b/src/models/individual/useQueryIndividuals.js
@@ -15,7 +15,7 @@ export default function useQueryIndividuals() {
       setLoading(true);
       setSearchTerm(queryString);
       const rawResponse = await axios.request({
-        url: `${__houston_url__}/api/v1/search/individuals`,
+        url: `${__houston_url__}/api/v1/search/proxy/individuals`,
         method: 'post',
         data: {
           _source: ['alias', 'name', 'id', 'genus', 'species'],


### PR DESCRIPTION
With the addition of Elasticsearch to houston in wildmeorg/houston#521, the `/api/v1/search/individuals` endpoint no longer exists. Eventually, we should use the new endpoint, `/api/v1/individuals/search`. However, that will also require changes to the request and response. So, for now, I am changing to `/api/v1/search/proxy/individuals`, which should function exactly the same as `/api/v1/search/individuals`.