### PR TITLE
DEX-803 make view buttons go to collaboration table directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "react-image-crop": "^8.6.1",
     "react-player": "^2.4.0",
     "react-query": "^3.34.1",
+    "react-router-hash-link": "^2.4.3",
     "react-transition-group": "^4.4.1",
     "uuid": "^3.4.0",
     "webpack-version-file": "^0.1.6"

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useHistory } from 'react-router-dom';
 import { get } from 'lodash-es';
 import { useQueryClient } from 'react-query';
 
@@ -15,6 +14,7 @@ import usePatchNotification from '../../models/notification/usePatchNotification
 import Link from '../Link';
 import Text from '../Text';
 import Button from '../Button';
+import ButtonLink from '../ButtonLink';
 import shane from '../../assets/shane.jpg';
 import { notificationSchema } from '../../constants/notificationSchema';
 import { calculatePrettyTimeElapsedSince } from '../../utils/formatters';
@@ -45,7 +45,6 @@ export default function NotificationsPane({
   setShouldOpen,
 }) {
   const intl = useIntl();
-  const history = useHistory();
   const queryClient = useQueryClient();
   const theme = useTheme();
   const [
@@ -118,38 +117,53 @@ export default function NotificationsPane({
                       )}
                     </div>
                     <div>
-                      <Button
-                        key={notification?.guid}
-                        display="primary"
-                        id="VIEW"
-                        onClick={async () => {
-                          if (showNotificationDialog) {
-                            const clickedNotificationType =
-                              notification?.message_type;
-                            const notificationDialog =
-                              notificationTypes[
-                                clickedNotificationType
-                              ];
-                            await markRead(get(notification, 'guid'));
-                            refreshNotifications();
-                            setShouldOpen(false);
-                            setActiveCollaborationNotification({
-                              notification,
-                              dialog: notificationDialog,
-                            });
-                          } else {
-                            const path =
-                              currentNotificationSchema?.buttonPath;
+                      {showNotificationDialog && (
+                        <Button
+                          key={notification?.guid}
+                          display="primary"
+                          id="VIEW"
+                          onClick={async () => {
+                            if (showNotificationDialog) {
+                              const clickedNotificationType =
+                                notification?.message_type;
+                              const notificationDialog =
+                                notificationTypes[
+                                  clickedNotificationType
+                                ];
+                              await markRead(
+                                get(notification, 'guid'),
+                              );
+                              refreshNotifications();
+                              setShouldOpen(false);
+                              setActiveCollaborationNotification({
+                                notification,
+                                dialog: notificationDialog,
+                              });
+                            }
+                          }}
+                        />
+                      )}
+                      {!showNotificationDialog && (
+                        <ButtonLink
+                          key={notification?.guid}
+                          display="primary"
+                          isHashLink
+                          href={get(
+                            currentNotificationSchema,
+                            'buttonPath',
+                            '/#collab-card',
+                          )}
+                          id="VIEW"
+                          onClick={async () => {
                             await markRead(get(notification, 'guid'));
                             queryClient.invalidateQueries(
                               queryKeys.me,
                             );
                             refreshNotifications();
                             setShouldOpen(false);
-                            history.push(path);
-                          }
-                        }}
-                      />
+                          }}
+                        />
+                      )}
                     </div>
                   </Grid>
                   <Grid

--- a/src/components/ButtonLink.jsx
+++ b/src/components/ButtonLink.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { HashLink } from 'react-router-hash-link';
 import Button from './Button';
 import Link from './Link';
 
@@ -7,9 +8,21 @@ export default function ButtonLink({
   href,
   external = false,
   newTab = false,
+  isHashLink = false,
   linkProps,
   ...rest
 }) {
+  if (isHashLink) {
+    return (
+      <HashLink
+        style={{ textDecoration: 'unset' }}
+        to={href}
+        {...linkProps}
+      >
+        <Button {...rest}>{children}</Button>
+      </HashLink>
+    );
+  }
   return (
     <Link
       noUnderline

--- a/src/components/UserProfile.jsx
+++ b/src/components/UserProfile.jsx
@@ -174,7 +174,12 @@ export default function UserProfile({
               someoneElse ? 'NO_SIGHTINGS_NON_SELF' : 'NO_SIGHTINGS'
             }
           />
-          {!someoneElse && <CollaborationsCard userId={userId} />}
+          {!someoneElse && (
+            <CollaborationsCard
+              htmlId="collab-card"
+              userId={userId}
+            />
+          )}
         </CardContainer>
       </div>
     </MainColumn>

--- a/src/components/cards/Card.jsx
+++ b/src/components/cards/Card.jsx
@@ -6,11 +6,13 @@ import Text from '../Text';
 export default function Card({
   title,
   titleId,
+  htmlId = null,
   renderActions,
   children,
 }) {
   return (
     <Grid
+      id={htmlId}
       item
       style={{ flex: 'auto', flexBasis: '100%', width: '100%' }}
     >

--- a/src/components/cards/CollaborationsCard.jsx
+++ b/src/components/cards/CollaborationsCard.jsx
@@ -10,7 +10,10 @@ import Link from '../Link';
 import DataDisplay from '../dataDisplays/DataDisplay';
 import CollaborationsDialog from './collaborations/CollaborationsDialog';
 
-export default function CollaborationsCard({ userId }) {
+export default function CollaborationsCard({
+  userId,
+  htmlId = null,
+}) {
   const intl = useIntl();
   const [activeCollaboration, setActiveCollaboration] = useState(
     null,
@@ -123,7 +126,7 @@ export default function CollaborationsCard({ userId }) {
   ];
 
   return (
-    <Card title="Collaborations">
+    <Card title="Collaborations" htmlId={htmlId}>
       <CollaborationsDialog
         open={Boolean(activeCollaboration)}
         onClose={() => setActiveCollaboration(null)}

--- a/src/constants/notificationSchema.js
+++ b/src/constants/notificationSchema.js
@@ -20,7 +20,7 @@ notificationSchemaPlaceholder[
   moreDetailedDescription:
     'A_COLLABORATION_WAS_CREATED_ON_YOUR_BEHALF_MORE_DETAILED',
   showNotificationDialog: false,
-  buttonPath: '/',
+  buttonPath: '/#collab-card',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_request
@@ -39,6 +39,7 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'COLLABORATION_APPROVED',
   showNotificationDialog: false,
   path: '/view_permission',
+  buttonPath: '/#collab-card',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_revoke
@@ -47,6 +48,7 @@ notificationSchemaPlaceholder[
   notificationMessage: 'COLLABORATION_REVOKE_BRIEF',
   moreDetailedDescription: 'COLLABORATION_REVOKE_BRIEF',
   showNotificationDialog: false,
+  buttonPath: '/#collab-card',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_edit_request
@@ -65,6 +67,7 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'EDIT_COLLABORATION_APPROVED',
   showNotificationDialog: false,
   path: '/edit_permission',
+  buttonPath: '/#collab-card',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_edit_revoke
@@ -73,7 +76,7 @@ notificationSchemaPlaceholder[
   notificationMessage: 'EDIT_COLLABORATION_REVOKED',
   moreDetailedDescription: 'EDIT_COLLABORATION_REVOKED',
   showNotificationDialog: false,
-  buttonPath: '/',
+  buttonPath: '/#collab-card',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_manager_revoke
@@ -82,7 +85,7 @@ notificationSchemaPlaceholder[
   notificationMessage: 'COLLABORATION_REVOKED_BY_MANAGER',
   moreDetailedDescription: 'COLLABORATION_REVOKED_BY_MANAGER',
   showNotificationDialog: false,
-  buttonPath: '/',
+  buttonPath: '/#collab-card',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.individual_merge_request


### PR DESCRIPTION
Addresses JH's QA feedback for DEX-803:

> Following up on our Slack conversation. I think all that is left is the make the notifications for a collaboration link to the collaboration table when the “View” button is clicked.

I tried to follow Emily's pattern from her recent PR and use useLocation. I don't think that it fit exactly my use case.
Instead, I followed some online advice(https://dev.to/gedalyakrycer/5-remarkable-react-router-features-anchor-links-query-params-more-2aeg#anchorLinks and https://stackoverflow.com/questions/40280369/use-anchors-with-react-router) and added the 'react-router-hash-link' package.

Slightly added to the ButtonLink component to make the use of HashLinks from within buttons easier going forward.