### PR TITLE
DEX-720 edit individual metadata default fields

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -422,6 +422,7 @@
   "FIELD_LABEL": "Field label",
   "FIELD_DESCRIPTION": "Field description",
   "REQUIRED": "Required",
+  "IS_REQUIRED": "{field} is required",
   "JOBS": "Jobs",
   "CHOOSE_ON_MAP": "Choose on map",
   "DECIMAL_LATITUDE": "Decimal Latitude",

--- a/src/models/individual/useIndividualFieldSchemas.js
+++ b/src/models/individual/useIndividualFieldSchemas.js
@@ -10,21 +10,6 @@ import {
 } from '../../utils/fieldUtils';
 import { defaultIndividualCategories } from '../../constants/fieldCategories';
 
-const statusChoices = [
-  {
-    value: 'alive',
-    labelId: 'ALIVE',
-  },
-  {
-    value: 'dead',
-    labelId: 'DEAD',
-  },
-  {
-    value: 'unknown',
-    labelId: 'UNKNOWN',
-  },
-];
-
 export default function useIndividualFieldSchemas() {
   const {
     data,
@@ -73,14 +58,6 @@ export default function useIndividualFieldSchemas() {
           choices: sexOptions,
           requiredForIndividualCreation: true,
           defaultValue: null,
-        }),
-        createFieldSchema(fieldTypes.select, {
-          name: 'status',
-          labelId: 'STATUS',
-          category: defaultIndividualCategories.general.name,
-          choices: statusChoices,
-          requiredForIndividualCreation: true,
-          defaultValue: '',
         }),
         ...customFieldSchemas,
       ];

--- a/src/models/individual/useIndividualFieldSchemas.js
+++ b/src/models/individual/useIndividualFieldSchemas.js
@@ -9,6 +9,7 @@ import {
   createCustomFieldSchema,
 } from '../../utils/fieldUtils';
 import { defaultIndividualCategories } from '../../constants/fieldCategories';
+import { deriveIndividualName } from '../../utils/nameUtils';
 
 export default function useIndividualFieldSchemas() {
   const {
@@ -43,6 +44,8 @@ export default function useIndividualFieldSchemas() {
           requiredForIndividualCreation: true,
           required: true,
           defaultValue: '',
+          getValue: (_, individualData) =>
+            deriveIndividualName(individualData, 'defaultName', ''),
         }),
         createFieldSchema(fieldTypes.string, {
           name: 'nickname',
@@ -50,6 +53,8 @@ export default function useIndividualFieldSchemas() {
           category: defaultIndividualCategories.general.name,
           requiredForIndividualCreation: true,
           defaultValue: '',
+          getValue: (_, individualData) =>
+            deriveIndividualName(individualData, 'nickname', ''),
         }),
         createFieldSchema(fieldTypes.select, {
           name: 'sex',

--- a/src/models/individual/usePatchIndividual.js
+++ b/src/models/individual/usePatchIndividual.js
@@ -53,11 +53,27 @@ export default function usePatchIndividual() {
     individualId,
     dictionary,
   ) => {
-    const operations = Object.keys(dictionary).map(propertyKey => ({
-      op: 'replace',
-      path: `/${propertyKey}`,
-      value: dictionary[propertyKey],
-    }));
+    // names must be handled separately because (1) multiple request with the path /names could be
+    // required, and (2) a name may need to be added or replaced.
+    const { names = [], ...dictionaryWithoutNames } = dictionary;
+
+    let operations = Object.keys(dictionaryWithoutNames).map(
+      propertyKey => ({
+        op: 'replace',
+        path: `/${propertyKey}`,
+        value: dictionaryWithoutNames[propertyKey],
+      }),
+    );
+
+    if (names.length > 0) {
+      const nameOperations = names.map(({ op, ...value }) => ({
+        op,
+        path: '/names',
+        value,
+      }));
+      operations = [...operations, ...nameOperations];
+    }
+
     return patchIndividual(individualId, operations);
   };
 

--- a/src/pages/individual/EditIndividualMetadata.jsx
+++ b/src/pages/individual/EditIndividualMetadata.jsx
@@ -149,20 +149,22 @@ export default function EditIndividualMetadata({
             // validation
             const requiredFieldErrors = metadata.reduce(
               (memo, schema) => {
-                if (!schema?.required) return memo;
+                // TODO: Once custom fields can be edited, include them in validation
+                if (
+                  schema &&
+                  (!schema.required || schema.customField)
+                )
+                  return memo;
 
-                const formObject = schema.customField
-                  ? customFieldValues
-                  : defaultFieldValues;
+                if (!defaultFieldValues[schema.name]) {
+                  const fieldName = schema.labelId
+                    ? intl.formatMessage({ id: schema.labelId })
+                    : schema.label;
 
-                if (!formObject[schema.name]) {
-                  const intlFieldName = intl.formatMessage({
-                    id: schema.labelId,
-                  });
                   memo.push(
                     intl.formatMessage(
                       { id: 'IS_REQUIRED' },
-                      { field: intlFieldName },
+                      { field: fieldName },
                     ),
                   );
                 }

--- a/src/pages/individual/EditIndividualMetadata.jsx
+++ b/src/pages/individual/EditIndividualMetadata.jsx
@@ -124,7 +124,9 @@ export default function EditIndividualMetadata({
           <CustomAlert severity="error" titleId="SUBMISSION_ERROR">
             {formErrors.length > 0 &&
               formErrors.map(formError => (
-                <Text variant="body2">{formError}</Text>
+                <Text key={formError} variant="body2">
+                  {formError}
+                </Text>
               ))}
             {patchIndividualError && (
               <Text variant="body2">{patchIndividualError}</Text>
@@ -177,7 +179,6 @@ export default function EditIndividualMetadata({
             setFormErrors(requiredFieldErrors);
             if (requiredFieldErrors.length > 0) return;
 
-            const names = [];
             // Always include the defaultName. If it does not already exist, add it.
             // Otherwise, replace it.
             const defaultNameGuid = deriveNameGuid(
@@ -195,7 +196,8 @@ export default function EditIndividualMetadata({
                   value: defaultFieldValues.defaultName,
                   context: 'defaultName',
                 };
-            names.push(defaultNameProperty);
+
+            const names = [defaultNameProperty];
 
             // If there was a nickname, update it with whatever the value is now.
             // If there was not a nickname, but there is a value now, add it.

--- a/src/pages/individual/EditIndividualMetadata.jsx
+++ b/src/pages/individual/EditIndividualMetadata.jsx
@@ -156,10 +156,14 @@ export default function EditIndividualMetadata({
                   : defaultFieldValues;
 
                 if (!formObject[schema.name]) {
+                  const intlFieldName = intl.formatMessage({
+                    id: schema.labelId,
+                  });
                   memo.push(
-                    `${intl.formatMessage({
-                      id: schema.labelId,
-                    })} is required.`,
+                    intl.formatMessage(
+                      { id: 'IS_REQUIRED' },
+                      { field: intlFieldName },
+                    ),
                   );
                 }
 

--- a/src/pages/individual/Individual.jsx
+++ b/src/pages/individual/Individual.jsx
@@ -55,7 +55,7 @@ export default function Individual() {
       const queryKey = getIndividualQueryKey(id);
       queryClient.invalidateQueries(queryKey);
     },
-    [queryClient],
+    [queryClient, id],
   );
 
   const metadata = useMemo(

--- a/src/pages/individual/Individual.jsx
+++ b/src/pages/individual/Individual.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { get, capitalize } from 'lodash-es';
@@ -35,6 +35,10 @@ import MergeDialog from './MergeDialog';
 import fakeAssets from './fakeAssets';
 import fakeCoocs from './fakeCoocs';
 import fakeRelationships from './fakeRelationships';
+import {
+  deriveIndividualName,
+  deriveIndividualNameGuid,
+} from '../../utils/nameUtils';
 
 export default function Individual() {
   const intl = useIntl();
@@ -46,7 +50,7 @@ export default function Individual() {
   const history = useHistory();
   const fieldSchemas = useIndividualFieldSchemas();
 
-  const refreshIndividualData = useMemo(
+  const refreshIndividualData = useCallback(
     () => {
       const queryKey = getIndividualQueryKey(id);
       queryClient.invalidateQueries(queryKey);
@@ -57,22 +61,45 @@ export default function Individual() {
   const metadata = useMemo(
     () => {
       if (!individualData || !fieldSchemas) return null;
-      return fieldSchemas.map(schema => ({
-        ...schema,
-        value: schema.getValue(schema, individualData),
-      }));
+      return fieldSchemas.map(schema => {
+        const augmentedSchema = {
+          ...schema,
+          value: schema.getValue(schema, individualData),
+        };
+
+        if (schema.name === 'defaultName') {
+          augmentedSchema.nameGuid = deriveIndividualNameGuid(
+            individualData,
+            'defaultName',
+          );
+        } else if (schema.name === 'nickname') {
+          augmentedSchema.nameGuid = deriveIndividualNameGuid(
+            individualData,
+            'nickname',
+          );
+        }
+
+        return augmentedSchema;
+      });
     },
     [individualData, fieldSchemas],
   );
 
-  const names = individualData?.names || [];
-  const defaultNameObject = names.find(
-    n => n.context === 'defaultName',
+  const [defaultName, nickname] = useMemo(
+    () => [
+      deriveIndividualName(
+        individualData,
+        'defaultName',
+        'Unnamed individual',
+      ),
+      deriveIndividualName(
+        individualData,
+        'nickname',
+        'Unnamed individual',
+      ),
+    ],
+    [individualData],
   );
-  const defaultName =
-    defaultNameObject?.value || 'Unnamed individual';
-  const nicknameObject = names.find(n => n.context === 'nickname');
-  const nickname = nicknameObject?.value || 'Unnamed individual';
 
   const {
     deleteIndividual,
@@ -195,7 +222,11 @@ export default function Individual() {
             )}
             assets={fakeAssets}
           />
-          <MetadataCard editable metadata={metadata} />
+          <MetadataCard
+            editable
+            metadata={metadata}
+            onEdit={() => setEditingProfile(true)}
+          />
         </CardContainer>
         <CardContainer>
           <EncountersCard

--- a/src/pages/individual/Individual.jsx
+++ b/src/pages/individual/Individual.jsx
@@ -46,10 +46,13 @@ export default function Individual() {
   const history = useHistory();
   const fieldSchemas = useIndividualFieldSchemas();
 
-  function refreshIndividualData() {
-    const queryKey = getIndividualQueryKey(id);
-    queryClient.invalidateQueries(queryKey);
-  }
+  const refreshIndividualData = useMemo(
+    () => {
+      const queryKey = getIndividualQueryKey(id);
+      queryClient.invalidateQueries(queryKey);
+    },
+    [queryClient],
+  );
 
   const metadata = useMemo(
     () => {

--- a/src/pages/sighting/encounters/CreateIndividualModal.jsx
+++ b/src/pages/sighting/encounters/CreateIndividualModal.jsx
@@ -133,6 +133,7 @@ export default function CreateIndividualModal({
                 });
               const individualData = {
                 names,
+                sex: formState?.sex,
               };
               const newId = await postIndividual(
                 individualData,

--- a/src/utils/nameUtils.js
+++ b/src/utils/nameUtils.js
@@ -1,9 +1,21 @@
+function getNameObject(individualData, context) {
+  const names = individualData?.names || [];
+  return names.find(n => n?.context === context) || {};
+}
+
 export function deriveIndividualName(
   individualData,
   context = 'defaultName',
   fallback = undefined,
 ) {
-  const names = individualData?.names || [];
-  const nameObject = names.find(n => n?.context === context) || {};
+  const nameObject = getNameObject(individualData, context);
   return nameObject?.value || fallback;
+}
+
+export function deriveIndividualNameGuid(
+  individualData,
+  context = 'defaultName',
+) {
+  const nameObject = getNameObject(individualData, context);
+  return nameObject?.guid;
 }


### PR DESCRIPTION
- On the individuals page, reads the metadata values on the metadata card.
- Enables editing of the individual metadata. If the individual does not have a nickname, and none is added, the nickname is not sent as part of the PATCH request.
- Adds validation for required fields to the edit individual metadata form. 
- Removes status as a default field. After discussion, it was decided that users can add it as a custom field if they want to track status. 

I left the names as defaultName/Name and nickname/Nickname(s) for now.

