### PR TITLE
change front end to reflect back end change from declined to denied

### DIFF
--- a/src/components/cards/collaborations/collaborationStates.js
+++ b/src/components/cards/collaborations/collaborationStates.js
@@ -34,12 +34,12 @@ export default {
     actionVerificationMessage2:
       'Are you sure you want to deny access?',
     getActionPatch2: testKey =>
-      buildCollaborationPatch(testKey, 'declined'),
+      buildCollaborationPatch(testKey, 'denied'),
   },
   blocked: {
     viewDisablesEdit: true,
     test: (testKey, collaboration) =>
-      ['declined', 'revoked'].includes(
+      ['denied', 'revoked'].includes(
         get(collaboration, ['otherUserData', testKey]),
       ),
     currentStateMessage:
@@ -48,7 +48,7 @@ export default {
   blocking: {
     viewDisablesEdit: true,
     test: (testKey, collaboration) =>
-      ['declined', 'revoked'].includes(
+      ['denied', 'revoked'].includes(
         get(collaboration, ['thisUserData', testKey]),
       ),
     currentStateMessage: 'You have revoked access.',

--- a/src/components/dialogs/notificationDialogUtils/NotificationCollaborationEditRequestDialog.jsx
+++ b/src/components/dialogs/notificationDialogUtils/NotificationCollaborationEditRequestDialog.jsx
@@ -46,7 +46,7 @@ export default function NotificationCollaborationEditRequestDialog({
       {
         op: 'replace',
         path,
-        value: 'declined',
+        value: 'denied',
       },
     ]);
     if (response?.status === 200) {

--- a/src/components/dialogs/notificationDialogUtils/NotificationCollaborationRequestDialog.jsx
+++ b/src/components/dialogs/notificationDialogUtils/NotificationCollaborationRequestDialog.jsx
@@ -46,7 +46,7 @@ export default function NotificationCollaborationRequestDialog({
       {
         op: 'replace',
         path,
-        value: 'declined',
+        value: 'denied',
       },
     ]);
     if (response?.status === 200) {

--- a/src/components/dialogs/notificationDialogUtils/NotificationIndividualMergeRequestDialog.jsx
+++ b/src/components/dialogs/notificationDialogUtils/NotificationIndividualMergeRequestDialog.jsx
@@ -47,7 +47,7 @@ export default function NotificationIndividualMergeDialog({
       {
         op: 'replace',
         path,
-        value: 'declined',
+        value: 'denied',
       },
     ]);
     if (response?.status === 200) {


### PR DESCRIPTION
Back end standardized all "declined" patches, etc. to "denied". Confirmed that it doesn't work the old way and works this new way.