### PR TITLE
DEX-862 fix individual name update

### DIFF
--- a/src/pages/individual/EditIndividualMetadata.jsx
+++ b/src/pages/individual/EditIndividualMetadata.jsx
@@ -183,7 +183,7 @@ export default function EditIndividualMetadata({
             // Otherwise, replace it.
             const firstNameGuid = deriveNameGuid(
               metadata,
-              'FirstName',
+              'firstName',
             );
             const firstNameProperty = firstNameGuid
               ? {
@@ -204,7 +204,7 @@ export default function EditIndividualMetadata({
             // If an adoptionName did not already exist, don't add it.
             const adoptionNameGuid = deriveNameGuid(
               metadata,
-              'AdoptionName',
+              'adoptionName',
             );
             const adoptionNameFieldValue =
               defaultFieldValues.adoptionName;


### PR DESCRIPTION
Updating an existing name was resulting in an error. Because the incorrect schema names were being passed to `deriveNameGuid`, no guids were found, and the operation in the PATCH request to houston was being set as "add" instead of "replace". This bug was introduced in #294. 

As a part of the fix, I looked into simplifying the request to only use replace and send a guid if it didn't already exist. However, houston throws an exception if the guid in the request does not match an existing name.
https://github.com/WildMeOrg/houston/blob/1ce45296747b4d3becd1f794e8e25053c80f0f33/app/modules/individuals/parameters.py#L210-L216