### PR TITLE
DEX-721 individual metadata custom fields

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -430,7 +430,6 @@
   "FIELD_LABEL": "Field label",
   "FIELD_DESCRIPTION": "Field description",
   "REQUIRED": "Required",
-  "IS_REQUIRED": "{field} is required",
   "JOBS": "Jobs",
   "CHOOSE_ON_MAP": "Choose on map",
   "DECIMAL_LATITUDE": "Decimal Latitude",

--- a/src/pages/individual/EditIndividualMetadata.jsx
+++ b/src/pages/individual/EditIndividualMetadata.jsx
@@ -72,12 +72,24 @@ export default function EditIndividualMetadata({
   const showErrorAlert =
     patchIndividualError || formErrors.length > 0;
 
+  function handleClose() {
+    setDefaultFieldValues(
+      getInitialFormValues(defaultFieldMetadata, 'name'),
+    );
+    setCustomFieldValues(
+      getInitialFormValues(customFieldMetadata, 'id'),
+    );
+    setPatchIndividualError(null);
+    setFormErrors([]);
+    onClose();
+  }
+
   return (
     <StandardDialog
       PaperProps={{ style: { width: 800 } }}
       maxWidth="lg"
       open={open}
-      onClose={onClose}
+      onClose={handleClose}
       titleId="EDIT_INDIVIDUAL_METADATA"
     >
       <DialogContent style={{ minWidth: 200 }}>
@@ -135,15 +147,7 @@ export default function EditIndividualMetadata({
         )}
       </DialogContent>
       <DialogActions style={{ padding: '0px 24px 24px 24px' }}>
-        <Button
-          display="basic"
-          onClick={() => {
-            setPatchIndividualError(null);
-            setFormErrors([]);
-            onClose();
-          }}
-          id="CANCEL"
-        />
+        <Button display="basic" onClick={handleClose} id="CANCEL" />
         <Button
           loading={loading}
           display="primary"

--- a/src/pages/individual/EditIndividualMetadata.jsx
+++ b/src/pages/individual/EditIndividualMetadata.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
-import { get, set } from 'lodash-es';
+import { get, isEmpty, set } from 'lodash-es';
 
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -223,6 +223,11 @@ export default function EditIndividualMetadata({
             }
 
             const properties = { sex: defaultFieldValues.sex, names };
+
+            if (!isEmpty(customFieldValues)) {
+              properties.customFields = customFieldValues;
+            }
+
             const successfulUpdate = await updateIndividualProperties(
               individualId,
               properties,

--- a/src/pages/individual/EditIndividualMetadata.jsx
+++ b/src/pages/individual/EditIndividualMetadata.jsx
@@ -151,22 +151,21 @@ export default function EditIndividualMetadata({
             // validation
             const requiredFieldErrors = metadata.reduce(
               (memo, schema) => {
-                // TODO: Once custom fields can be edited, include them in validation
-                if (
-                  schema &&
-                  (!schema.required || schema.customField)
-                )
-                  return memo;
+                if (!schema.required) return memo;
 
-                if (!defaultFieldValues[schema.name]) {
+                const isFieldEmpty = schema.customField
+                  ? !customFieldValues[schema.id]
+                  : !defaultFieldValues[schema.name];
+
+                if (isFieldEmpty) {
                   const fieldName = schema.labelId
                     ? intl.formatMessage({ id: schema.labelId })
                     : schema.label;
 
                   memo.push(
                     intl.formatMessage(
-                      { id: 'IS_REQUIRED' },
-                      { field: fieldName },
+                      { id: 'INCOMPLETE_FIELD' },
+                      { fieldName },
                     ),
                   );
                 }

--- a/src/pages/individual/EditIndividualMetadata.jsx
+++ b/src/pages/individual/EditIndividualMetadata.jsx
@@ -162,7 +162,7 @@ export default function EditIndividualMetadata({
             // validation
             const requiredFieldErrors = metadata.reduce(
               (memo, schema) => {
-                if (!schema.required) return memo;
+                if (!schema?.required) return memo;
 
                 const isFieldEmpty = schema.customField
                   ? !customFieldValues[schema.id]

--- a/src/pages/individual/EditIndividualMetadata.jsx
+++ b/src/pages/individual/EditIndividualMetadata.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { get, isEmpty, set } from 'lodash-es';
 
@@ -17,6 +17,14 @@ function deriveNameGuid(metadata, schemaName) {
     schema => schema.name === schemaName,
   );
   return foundSchema?.nameGuid;
+}
+
+function getDefaultFieldMetadata(metadata = []) {
+  return metadata.filter(field => !field.customField);
+}
+
+function getCustomFieldMetadata(metadata = []) {
+  return metadata.filter(field => field.customField);
 }
 
 function getInitialFormValues(schema, fieldKey) {
@@ -52,19 +60,12 @@ export default function EditIndividualMetadata({
   metadata = metadata || [];
   // hotfix //
 
-  const defaultFieldMetadata = metadata.filter(
-    field => !field.customField,
-  );
-  const customFieldMetadata = metadata.filter(
-    field => field.customField,
-  );
-
   const [defaultFieldValues, setDefaultFieldValues] = useState(
-    getInitialFormValues(defaultFieldMetadata, 'name'),
+    getInitialFormValues(getDefaultFieldMetadata(metadata), 'name'),
   );
 
   const [customFieldValues, setCustomFieldValues] = useState(
-    getInitialFormValues(customFieldMetadata, 'id'),
+    getInitialFormValues(getCustomFieldMetadata(metadata), 'id'),
   );
 
   const [formErrors, setFormErrors] = useState([]);
@@ -72,17 +73,23 @@ export default function EditIndividualMetadata({
   const showErrorAlert =
     patchIndividualError || formErrors.length > 0;
 
-  function handleClose() {
-    setDefaultFieldValues(
-      getInitialFormValues(defaultFieldMetadata, 'name'),
-    );
-    setCustomFieldValues(
-      getInitialFormValues(customFieldMetadata, 'id'),
-    );
-    setPatchIndividualError(null);
-    setFormErrors([]);
-    onClose();
-  }
+  const handleClose = useCallback(
+    () => {
+      setDefaultFieldValues(
+        getInitialFormValues(
+          getDefaultFieldMetadata(metadata),
+          'name',
+        ),
+      );
+      setCustomFieldValues(
+        getInitialFormValues(getCustomFieldMetadata(metadata), 'id'),
+      );
+      setPatchIndividualError(null);
+      setFormErrors([]);
+      onClose();
+    },
+    [metadata, setPatchIndividualError, onClose],
+  );
 
   return (
     <StandardDialog


### PR DESCRIPTION
- Enables custom field editing for individuals, including validation of required fields.
- Resets the EditIndividualMetadata form values when the cancel or close buttons are clicked.
  - Updates the close button callback so that the behavior is the same whether the cancel button or the close button is clicked.
- Removes a duplicate entry from `locale/en.json`