### PR TITLE
DEX 845 - cleanup encounters table wrapping

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,19 +1,22 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useTheme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import BackIcon from '@material-ui/icons/KeyboardBackspace';
 
-const Core = function({
-  children,
-  display = 'panel',
-  loading = false,
-  style,
-  disabled,
-  size,
-  ...rest
-}) {
+const Core = function(
+  {
+    children,
+    display = 'panel',
+    loading = false,
+    style,
+    disabled,
+    size,
+    ...rest
+  },
+  ref,
+) {
   const theme = useTheme();
 
   let variant = undefined; // eslint-disable-line
@@ -33,6 +36,7 @@ const Core = function({
           padding: '4px 16px',
           ...style,
         }}
+        ref={ref}
         {...rest}
       >
         {children}
@@ -96,6 +100,7 @@ const Core = function({
       <button
         type="button"
         style={{ ...roleStyles, ...style }}
+        ref={ref}
         {...rest}
       >
         {loading ? (
@@ -119,6 +124,7 @@ const Core = function({
       disabled={disabled}
       style={{ ...roleStyles, ...style }}
       size={size}
+      ref={ref}
       {...rest}
     >
       {loading ? (
@@ -130,22 +136,23 @@ const Core = function({
   );
 };
 
-export default function CustomButton({
-  id,
-  domId = undefined,
-  values,
-  children,
-  ...rest
-}) {
+const CoreForwardRef = forwardRef(Core);
+
+function CustomButton(
+  { id, domId = undefined, values, children, ...rest },
+  ref,
+) {
   if (!id)
     return (
-      <Core id={domId} {...rest}>
+      <CoreForwardRef id={domId} ref={ref} {...rest}>
         {children}
-      </Core>
+      </CoreForwardRef>
     );
   return (
-    <Core id={domId} {...rest}>
+    <CoreForwardRef id={domId} ref={ref} {...rest}>
       <FormattedMessage id={id} values={values} />
-    </Core>
+    </CoreForwardRef>
   );
 }
+
+export default forwardRef(CustomButton);

--- a/src/components/Link.jsx
+++ b/src/components/Link.jsx
@@ -1,18 +1,21 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { useTheme } from '@material-ui/core/styles';
 
-export default function Link({
-  children,
-  href,
-  style,
-  disabled = false,
-  noUnderline = false,
-  external = false,
-  newTab = false,
-  onClick,
-  ...rest
-}) {
+function Link(
+  {
+    children,
+    href,
+    style,
+    disabled = false,
+    noUnderline = false,
+    external = false,
+    newTab = false,
+    onClick,
+    ...rest
+  },
+  ref,
+) {
   const theme = useTheme();
 
   const styles = {
@@ -24,7 +27,7 @@ export default function Link({
 
   if (disabled) {
     return (
-      <div style={styles} {...rest}>
+      <div style={styles} ref={ref} {...rest}>
         {children}
       </div>
     );
@@ -38,6 +41,7 @@ export default function Link({
         rel={newTab ? 'noreferrer' : undefined}
         style={styles}
         onClick={onClick}
+        ref={ref}
         {...rest}
       >
         {children}
@@ -52,9 +56,12 @@ export default function Link({
       onClick={onClick}
       target={newTab ? '_blank' : undefined}
       rel={newTab ? 'noreferrer' : undefined}
+      ref={ref}
       {...rest}
     >
       {children}
     </RouterLink>
   );
 }
+
+export default forwardRef(Link);

--- a/src/components/ResponsiveText.jsx
+++ b/src/components/ResponsiveText.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { get } from 'lodash-es';
 import { useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
@@ -32,14 +32,17 @@ const sizeMap = {
   },
 };
 
-export default function ResponsiveText({
-  variant,
-  children,
-  mobileStyle = {},
-  desktopStyle = {},
-  style = {},
-  ...rest
-}) {
+function ResponsiveText(
+  {
+    variant,
+    children,
+    mobileStyle = {},
+    desktopStyle = {},
+    style = {},
+    ...rest
+  },
+  ref,
+) {
   const theme = useTheme();
   const isSm = useMediaQuery(theme.breakpoints.down('sm'));
   const smallSize = get(sizeMap, [variant, 'mobile'], 12);
@@ -55,9 +58,12 @@ export default function ResponsiveText({
       variant={variant}
       component={component}
       style={{ ...responsiveStyle, ...style }}
+      ref={ref}
       {...rest}
     >
       {children}
     </Typography>
   );
 }
+
+export default forwardRef(ResponsiveText);

--- a/src/components/Text.jsx
+++ b/src/components/Text.jsx
@@ -1,30 +1,28 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import Typography from '@material-ui/core/Typography';
 import ResponsiveText from './ResponsiveText';
 
-const Core = function(props) {
+function Core(props, ref) {
   const { responsive = false, ...rest } = props;
-  if (responsive) return <ResponsiveText {...rest} />;
-  return <Typography {...rest} />;
-};
+  if (responsive) return <ResponsiveText ref={ref} {...rest} />;
+  return <Typography ref={ref} {...rest} />;
+}
 
-export default function Text({
-  id,
-  values,
-  domId,
-  children,
-  ...rest
-}) {
+const CoreForwardRef = forwardRef(Core);
+
+function Text({ id, values, domId, children, ...rest }, ref) {
   if (!id)
     return (
-      <Core id={domId} {...rest}>
+      <CoreForwardRef id={domId} ref={ref} {...rest}>
         {children}
-      </Core>
+      </CoreForwardRef>
     );
   return (
-    <Core id={domId} {...rest}>
+    <CoreForwardRef id={domId} ref={ref} {...rest}>
       <FormattedMessage id={id} values={values} />
-    </Core>
+    </CoreForwardRef>
   );
 }
+
+export default forwardRef(Text);

--- a/src/components/cards/EncountersCard.jsx
+++ b/src/components/cards/EncountersCard.jsx
@@ -58,31 +58,56 @@ export default function EncountersCard({
       reference: 'date',
       name: 'time',
       label: 'Date',
-      options: { cellRenderer: cellRendererTypes.specifiedTime },
+      options: {
+        cellRenderer: cellRendererTypes.specifiedTime,
+        cellRendererProps: { noWrap: true },
+        width: '20%',
+      },
     },
     {
       reference: 'location',
       name: 'formattedLocation',
       label: 'Location',
-      options: { cellRenderer: cellRendererTypes.location },
+      options: {
+        cellRenderer: cellRendererTypes.location,
+        cellRendererProps: { noWrap: true },
+      },
     },
     {
       reference: 'owner',
       name: 'owner',
       label: 'Owner',
-      options: { cellRenderer: cellRendererTypes.user },
+      options: {
+        cellRenderer: cellRendererTypes.user,
+        cellRendererProps: { noWrap: true },
+      },
     },
     {
       reference: 'actions',
       name: 'guid',
       label: 'Actions',
       options: {
+        width: (function buildWidth() {
+          const numberOfActions = 2;
+          // the following values were determined by inspecting the resulting DOM elements.
+          const actionWidth = '1.5rem';
+          const totalActionPadding = `${numberOfActions *
+            theme.spacing(1)}px`;
+          const tableCellPadding = `${theme.spacing(4)}px`;
+          const actionLabelWidth = '73px';
+
+          const actionTdWidth = `calc(${numberOfActions} * ${actionWidth} + ${totalActionPadding} + ${tableCellPadding})`;
+          const actionThWidth = `calc(${actionLabelWidth} + ${tableCellPadding})`;
+          return `max(${actionTdWidth}, ${actionThWidth})`;
+        })(),
         customBodyRender: (_, encounter) => [
           <ActionIcon
+            key="view"
             variant="view"
             href={`/sightings/${encounter?.sighting}`}
           />,
           <ActionIcon
+            key="remove"
             variant={
               tooFewEncounters
                 ? 'removeEncFromIndividualDisabled'
@@ -149,6 +174,7 @@ export default function EncountersCard({
           tableSize="medium"
           columns={filteredColumns}
           data={encountersWithLocationData}
+          tableStyles={{ tableLayout: 'fixed' }}
         />
       )}
       {!noEncounters && showMapView && <div>Map goes here</div>}

--- a/src/components/cards/EncountersCard.jsx
+++ b/src/components/cards/EncountersCard.jsx
@@ -8,6 +8,7 @@ import ViewList from '@material-ui/icons/ViewList';
 import ViewMap from '@material-ui/icons/Language';
 
 import { formatLocationFromSighting } from '../../utils/formatters';
+import useActionsColumnWidth from '../../hooks/useActionsColumnWidth';
 import useOptions from '../../hooks/useOptions';
 import { cellRendererTypes } from '../dataDisplays/cellRenderers';
 import Text from '../Text';
@@ -87,19 +88,7 @@ export default function EncountersCard({
       name: 'guid',
       label: 'Actions',
       options: {
-        width: (function buildWidth() {
-          const numberOfActions = 2;
-          // the following values were determined by inspecting the resulting DOM elements.
-          const actionWidth = '1.5rem';
-          const totalActionPadding = `${numberOfActions *
-            theme.spacing(1)}px`;
-          const tableCellPadding = `${theme.spacing(4)}px`;
-          const actionLabelWidth = '73px';
-
-          const actionTdWidth = `calc(${numberOfActions} * ${actionWidth} + ${totalActionPadding} + ${tableCellPadding})`;
-          const actionThWidth = `calc(${actionLabelWidth} + ${tableCellPadding})`;
-          return `max(${actionTdWidth}, ${actionThWidth})`;
-        })(),
+        width: useActionsColumnWidth(2),
         customBodyRender: (_, encounter) => [
           <ActionIcon
             key="view"

--- a/src/components/dataDisplays/DataDisplay.jsx
+++ b/src/components/dataDisplays/DataDisplay.jsx
@@ -65,6 +65,7 @@ export default function DataDisplay({
   rowsPerPage,
   dataCount, // in a paginated table there will be more data than provided to the data prop
   paperStyles = {},
+  tableStyles = {},
   cellStyles = {},
   ...rest
 }) {
@@ -257,10 +258,22 @@ export default function DataDisplay({
         style={paperStyles}
       >
         <Table
-          style={{ minWidth: 10 }}
+          style={{ minWidth: 10, ...tableStyles }}
           size={tableSize}
           aria-label={title}
         >
+          <colgroup>
+            {columns.map(c => (
+              <col
+                key={c.name}
+                style={
+                  get(c, 'options.width')
+                    ? { width: c.options.width }
+                    : {}
+                }
+              />
+            ))}
+          </colgroup>
           <TableHead>
             <TableRow>
               {renderExpandedRow && <TableCell />}

--- a/src/components/dataDisplays/cellRenderers/CapitalizedStringRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/CapitalizedStringRenderer.jsx
@@ -20,13 +20,13 @@ export default function CapitalizedStringRenderer({
 }) {
   const capitalizedValue = capitalize(value);
 
-  const coreComponent = <CoreForwardRef value={capitalizedValue} />;
+  const CoreComponent = <CoreForwardRef value={capitalizedValue} />;
 
   return noWrap ? (
     <OverflowController title={capitalizedValue}>
-      {coreComponent}
+      {CoreComponent}
     </OverflowController>
   ) : (
-    coreComponent
+    CoreComponent
   );
 }

--- a/src/components/dataDisplays/cellRenderers/CapitalizedStringRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/CapitalizedStringRenderer.jsx
@@ -1,15 +1,32 @@
 import React, { forwardRef } from 'react';
-
 import { capitalize } from 'lodash-es';
 
+import OverflowController from './OverflowController';
 import Text from '../../Text';
 
-function CapitalizedStringRenderer({ value }, ref) {
+function Core({ value, ...rest }, ref) {
   return (
-    <Text variant="body2" ref={ref}>
-      {capitalize(value)}
+    <Text variant="body2" ref={ref} {...rest}>
+      {value}
     </Text>
   );
 }
 
-export default forwardRef(CapitalizedStringRenderer);
+const CoreForwardRef = forwardRef(Core);
+
+export default function CapitalizedStringRenderer({
+  value,
+  noWrap = false,
+}) {
+  const capitalizedValue = capitalize(value);
+
+  const coreComponent = <CoreForwardRef value={capitalizedValue} />;
+
+  return noWrap ? (
+    <OverflowController title={capitalizedValue}>
+      {coreComponent}
+    </OverflowController>
+  ) : (
+    coreComponent
+  );
+}

--- a/src/components/dataDisplays/cellRenderers/CapitalizedStringRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/CapitalizedStringRenderer.jsx
@@ -1,9 +1,15 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { capitalize } from 'lodash-es';
 
 import Text from '../../Text';
 
-export default function CapitalizedStringRenderer({ value }) {
-  return <Text variant="body2">{capitalize(value)}</Text>;
+function CapitalizedStringRenderer({ value }, ref) {
+  return (
+    <Text variant="body2" ref={ref}>
+      {capitalize(value)}
+    </Text>
+  );
 }
+
+export default forwardRef(CapitalizedStringRenderer);

--- a/src/components/dataDisplays/cellRenderers/DateRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/DateRenderer.jsx
@@ -1,14 +1,34 @@
 import React, { forwardRef } from 'react';
 import { get } from 'lodash-es';
+
 import { formatDate } from '../../../utils/formatters';
+import OverflowController from './OverflowController';
 import Text from '../../Text';
 
-function DateRenderer({ datum, accessor = 'created' }, ref) {
+function Core({ value, ...rest }, ref) {
   return (
-    <Text component="span" variant="body2" ref={ref}>
-      {formatDate(get(datum, accessor, ''))}
+    <Text component="span" variant="body2" ref={ref} {...rest}>
+      {value}
     </Text>
   );
 }
 
-export default forwardRef(DateRenderer);
+const CoreForwardRef = forwardRef(Core);
+
+export default function DateRenderer({
+  datum,
+  accessor = 'created',
+  noWrap = false,
+}) {
+  const formattedValue = formatDate(get(datum, accessor, ''));
+
+  const coreComponent = <CoreForwardRef value={formattedValue} />;
+
+  return noWrap ? (
+    <OverflowController title={formattedValue}>
+      {coreComponent}
+    </OverflowController>
+  ) : (
+    coreComponent
+  );
+}

--- a/src/components/dataDisplays/cellRenderers/DateRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/DateRenderer.jsx
@@ -1,15 +1,14 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { get } from 'lodash-es';
 import { formatDate } from '../../../utils/formatters';
 import Text from '../../Text';
 
-export default function DateRenderer({
-  datum,
-  accessor = 'created',
-}) {
+function DateRenderer({ datum, accessor = 'created' }, ref) {
   return (
-    <Text component="span" variant="body2">
+    <Text component="span" variant="body2" ref={ref}>
       {formatDate(get(datum, accessor, ''))}
     </Text>
   );
 }
+
+export default forwardRef(DateRenderer);

--- a/src/components/dataDisplays/cellRenderers/DateRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/DateRenderer.jsx
@@ -22,13 +22,13 @@ export default function DateRenderer({
 }) {
   const formattedValue = formatDate(get(datum, accessor, ''));
 
-  const coreComponent = <CoreForwardRef value={formattedValue} />;
+  const CoreComponent = <CoreForwardRef value={formattedValue} />;
 
   return noWrap ? (
     <OverflowController title={formattedValue}>
-      {coreComponent}
+      {CoreComponent}
     </OverflowController>
   ) : (
-    coreComponent
+    CoreComponent
   );
 }

--- a/src/components/dataDisplays/cellRenderers/DefaultRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/DefaultRenderer.jsx
@@ -1,7 +1,26 @@
 import React, { forwardRef } from 'react';
+import OverflowController from './OverflowController';
 
-function DefaultRenderer({ value }, ref) {
-  return <span ref={ref}>{value || ''}</span>;
+function Core({ value, ...rest }, ref) {
+  return (
+    <span ref={ref} {...rest}>
+      {value}
+    </span>
+  );
 }
 
-export default forwardRef(DefaultRenderer);
+const CoreForwardRef = forwardRef(Core);
+
+export default function DefaultRenderer({
+  value = '',
+  noWrap = false,
+}) {
+  const coreComponent = <CoreForwardRef value={value} />;
+  return noWrap ? (
+    <OverflowController title={value}>
+      {coreComponent}
+    </OverflowController>
+  ) : (
+    coreComponent
+  );
+}

--- a/src/components/dataDisplays/cellRenderers/DefaultRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/DefaultRenderer.jsx
@@ -15,12 +15,12 @@ export default function DefaultRenderer({
   value = '',
   noWrap = false,
 }) {
-  const coreComponent = <CoreForwardRef value={value} />;
+  const CoreComponent = <CoreForwardRef value={value} />;
   return noWrap ? (
     <OverflowController title={value}>
-      {coreComponent}
+      {CoreComponent}
     </OverflowController>
   ) : (
-    coreComponent
+    CoreComponent
   );
 }

--- a/src/components/dataDisplays/cellRenderers/DefaultRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/DefaultRenderer.jsx
@@ -1,3 +1,7 @@
-export default function DefaultRenderer({ value }) {
-  return value || '';
+import React, { forwardRef } from 'react';
+
+function DefaultRenderer({ value }, ref) {
+  return <span ref={ref}>{value || ''}</span>;
 }
+
+export default forwardRef(DefaultRenderer);

--- a/src/components/dataDisplays/cellRenderers/LocationRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/LocationRenderer.jsx
@@ -10,42 +10,15 @@ import StandardDialog from '../../StandardDialog';
 import SinglePoint from '../../maps/SinglePoint';
 import Button from '../../Button';
 import Text from '../../Text';
+import OverflowController from './OverflowController';
 
-function LocationRenderer(
-  {
-    datum,
-    locatationIdProperty = 'locationId',
-    latProperty = 'decimalLatitude',
-    lngProperty = 'decimalLongitude',
-    freeformProperty = 'verbatimLocality',
-  },
-  ref,
-) {
-  const intl = useIntl();
-  const { regionOptions } = useOptions();
+function Core({ value, lat, lng, ...rest }, ref) {
   const [dialogOpen, setDialogOpen] = useState(false);
-
-  const locationId = get(datum, locatationIdProperty);
-  const lat = get(datum, latProperty);
-  const lng = get(datum, lngProperty);
-  const freeform = get(datum, freeformProperty);
-
-  const matchingLocationIdObject = regionOptions.find(
-    opt => opt?.value === locationId,
-  );
-  const regionLabel =
-    matchingLocationIdObject?.label ||
-    intl.formatMessage({
-      id: 'REGION_NAME_REMOVED',
-    });
-  const text = freeform
-    ? `${regionLabel} (${freeform})`
-    : regionLabel;
 
   if (!lat || !lng)
     return (
-      <Text variant="body2" ref={ref}>
-        {text}
+      <Text variant="body2" ref={ref} {...rest}>
+        {value}
       </Text>
     );
 
@@ -77,11 +50,53 @@ function LocationRenderer(
         display="link"
         onClick={() => setDialogOpen(true)}
         ref={ref}
+        {...rest}
       >
-        {text}
+        {value}
       </Button>
     </>
   );
 }
 
-export default forwardRef(LocationRenderer);
+const CoreForwardRef = forwardRef(Core);
+
+export default function LocationRenderer({
+  datum,
+  locatationIdProperty = 'locationId',
+  latProperty = 'decimalLatitude',
+  lngProperty = 'decimalLongitude',
+  freeformProperty = 'verbatimLocality',
+  noWrap = false,
+}) {
+  const intl = useIntl();
+  const { regionOptions } = useOptions();
+
+  const locationId = get(datum, locatationIdProperty);
+  const lat = get(datum, latProperty);
+  const lng = get(datum, lngProperty);
+  const freeform = get(datum, freeformProperty);
+
+  const matchingLocationIdObject = regionOptions.find(
+    opt => opt?.value === locationId,
+  );
+  const regionLabel =
+    matchingLocationIdObject?.label ||
+    intl.formatMessage({
+      id: 'REGION_NAME_REMOVED',
+    });
+  const text = freeform
+    ? `${regionLabel} (${freeform})`
+    : regionLabel;
+
+  const coreComponent = (
+    <CoreForwardRef value={text} lat={lat} lng={lng} />
+  );
+
+  return noWrap ? (
+    <OverflowController title={text}>
+      {coreComponent}
+    </OverflowController>
+  ) : (
+    coreComponent
+  );
+}

--- a/src/components/dataDisplays/cellRenderers/LocationRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/LocationRenderer.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { get } from 'lodash-es';
 import { useIntl } from 'react-intl';
 
@@ -11,13 +11,16 @@ import SinglePoint from '../../maps/SinglePoint';
 import Button from '../../Button';
 import Text from '../../Text';
 
-export default function LocationRenderer({
-  datum,
-  locatationIdProperty = 'locationId',
-  latProperty = 'decimalLatitude',
-  lngProperty = 'decimalLongitude',
-  freeformProperty = 'verbatimLocality',
-}) {
+function LocationRenderer(
+  {
+    datum,
+    locatationIdProperty = 'locationId',
+    latProperty = 'decimalLatitude',
+    lngProperty = 'decimalLongitude',
+    freeformProperty = 'verbatimLocality',
+  },
+  ref,
+) {
   const intl = useIntl();
   const { regionOptions } = useOptions();
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -39,7 +42,12 @@ export default function LocationRenderer({
     ? `${regionLabel} (${freeform})`
     : regionLabel;
 
-  if (!lat || !lng) return <Text variant="body2">{text}</Text>;
+  if (!lat || !lng)
+    return (
+      <Text variant="body2" ref={ref}>
+        {text}
+      </Text>
+    );
 
   return (
     <>
@@ -65,9 +73,15 @@ export default function LocationRenderer({
           </>
         )}
       </StandardDialog>
-      <Button display="link" onClick={() => setDialogOpen(true)}>
+      <Button
+        display="link"
+        onClick={() => setDialogOpen(true)}
+        ref={ref}
+      >
         {text}
       </Button>
     </>
   );
 }
+
+export default forwardRef(LocationRenderer);

--- a/src/components/dataDisplays/cellRenderers/OverflowController.jsx
+++ b/src/components/dataDisplays/cellRenderers/OverflowController.jsx
@@ -8,7 +8,6 @@ const noWrapStyles = {
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-  width: '100%',
 };
 
 export default function OverflowController({ title, children }) {

--- a/src/components/dataDisplays/cellRenderers/OverflowController.jsx
+++ b/src/components/dataDisplays/cellRenderers/OverflowController.jsx
@@ -1,0 +1,62 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { debounce } from 'lodash-es';
+
+import Tooltip from '@material-ui/core/Tooltip';
+
+const noWrapStyles = {
+  display: 'block',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  width: '100%',
+};
+
+export default function OverflowController({ title, children }) {
+  const [isOverflowed, setIsOverflowed] = useState(false);
+  const [refEl, setRefEl] = useState();
+
+  const ref = useCallback(node => {
+    setRefEl(node);
+  }, []);
+
+  useEffect(
+    () => {
+      if (!refEl) return;
+
+      const debouncedHandleResize = debounce(function handleResize() {
+        const { clientWidth, scrollWidth } = refEl;
+        const overflow = scrollWidth - clientWidth > 0;
+        setIsOverflowed(overflow);
+      }, 200);
+
+      const resizeObserver = new ResizeObserver(
+        debouncedHandleResize,
+      );
+      resizeObserver.observe(refEl);
+
+      return function unobserveResizeObserver() {
+        resizeObserver.unobserve(refEl);
+      };
+    },
+    [refEl],
+  );
+
+  const childrenWithStyles = React.cloneElement(
+    React.Children.only(children),
+    {
+      ref,
+      style: noWrapStyles,
+    },
+  );
+
+  return (
+    <Tooltip
+      title={title}
+      disableFocusListener={!isOverflowed}
+      disableHoverListener={!isOverflowed}
+      disableTouchListener={!isOverflowed}
+    >
+      {childrenWithStyles}
+    </Tooltip>
+  );
+}

--- a/src/components/dataDisplays/cellRenderers/SpecifiedTimeRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/SpecifiedTimeRenderer.jsx
@@ -33,13 +33,13 @@ export default function SpecifiedTimeRenderer({
 
   const formattedValue = formatDateCustom(time, formatSpecification);
 
-  const coreComponent = <CoreForwardRef value={formattedValue} />;
+  const CoreComponent = <CoreForwardRef value={formattedValue} />;
 
   return noWrap ? (
     <OverflowController title={formattedValue}>
-      {coreComponent}
+      {CoreComponent}
     </OverflowController>
   ) : (
-    coreComponent
+    CoreComponent
   );
 }

--- a/src/components/dataDisplays/cellRenderers/SpecifiedTimeRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/SpecifiedTimeRenderer.jsx
@@ -3,16 +3,25 @@ import { get } from 'lodash-es';
 
 import { formatDateCustom } from '../../../utils/formatters';
 import timePrecisionMap from '../../../constants/timePrecisionMap';
+import OverflowController from './OverflowController';
 import Text from '../../Text';
 
-function SpecifiedTimeRenderer(
-  {
-    datum,
-    timeProperty = 'time',
-    specificityProperty = 'timeSpecificity',
-  },
-  ref,
-) {
+function Core({ value, ...rest }, ref) {
+  return (
+    <Text variant="body2" ref={ref} {...rest}>
+      {value}
+    </Text>
+  );
+}
+
+const CoreForwardRef = forwardRef(Core);
+
+export default function SpecifiedTimeRenderer({
+  datum,
+  timeProperty = 'time',
+  specificityProperty = 'timeSpecificity',
+  noWrap = false,
+}) {
   const time = get(datum, timeProperty);
   const specificity = get(datum, specificityProperty);
 
@@ -22,11 +31,15 @@ function SpecifiedTimeRenderer(
     'yyyy-MM-dd',
   );
 
-  return (
-    <Text variant="body2" ref={ref}>
-      {formatDateCustom(time, formatSpecification)}
-    </Text>
+  const formattedValue = formatDateCustom(time, formatSpecification);
+
+  const coreComponent = <CoreForwardRef value={formattedValue} />;
+
+  return noWrap ? (
+    <OverflowController title={formattedValue}>
+      {coreComponent}
+    </OverflowController>
+  ) : (
+    coreComponent
   );
 }
-
-export default forwardRef(SpecifiedTimeRenderer);

--- a/src/components/dataDisplays/cellRenderers/SpecifiedTimeRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/SpecifiedTimeRenderer.jsx
@@ -1,15 +1,18 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { get } from 'lodash-es';
 
 import { formatDateCustom } from '../../../utils/formatters';
 import timePrecisionMap from '../../../constants/timePrecisionMap';
 import Text from '../../Text';
 
-export default function SpecifiedTimeRenderer({
-  datum,
-  timeProperty = 'time',
-  specificityProperty = 'timeSpecificity',
-}) {
+function SpecifiedTimeRenderer(
+  {
+    datum,
+    timeProperty = 'time',
+    specificityProperty = 'timeSpecificity',
+  },
+  ref,
+) {
   const time = get(datum, timeProperty);
   const specificity = get(datum, specificityProperty);
 
@@ -20,8 +23,10 @@ export default function SpecifiedTimeRenderer({
   );
 
   return (
-    <Text variant="body2">
+    <Text variant="body2" ref={ref}>
       {formatDateCustom(time, formatSpecification)}
     </Text>
   );
 }
+
+export default forwardRef(SpecifiedTimeRenderer);

--- a/src/components/dataDisplays/cellRenderers/UserRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/UserRenderer.jsx
@@ -1,23 +1,38 @@
 import React, { forwardRef } from 'react';
 import { get } from 'lodash-es';
-import Link from '../../Link';
 
-function UserRenderer(
-  {
-    datum,
-    guidProperty = 'owner.guid',
-    nameProperty = 'owner.full_name',
-    fallbackName = 'Unnamed User',
-  },
-  ref,
-) {
-  const userGuid = get(datum, guidProperty);
-  const userName = get(datum, nameProperty, fallbackName);
+import Link from '../../Link';
+import OverflowController from './OverflowController';
+
+function Core({ value, guid, ...rest }, ref) {
   return (
-    <Link href={`/users/${userGuid}`} ref={ref}>
-      {userName}
+    <Link href={`/users/${guid}`} ref={ref} {...rest}>
+      {value}
     </Link>
   );
 }
 
-export default forwardRef(UserRenderer);
+const CoreForwardRef = forwardRef(Core);
+
+export default function UserRenderer({
+  datum,
+  guidProperty = 'owner.guid',
+  nameProperty = 'owner.full_name',
+  fallbackName = 'Unnamed User',
+  noWrap = false,
+}) {
+  const userGuid = get(datum, guidProperty);
+  const userName = get(datum, nameProperty, fallbackName);
+
+  const coreComponent = (
+    <CoreForwardRef value={userName} guid={userGuid} />
+  );
+
+  return noWrap ? (
+    <OverflowController title={userName}>
+      {coreComponent}
+    </OverflowController>
+  ) : (
+    coreComponent
+  );
+}

--- a/src/components/dataDisplays/cellRenderers/UserRenderer.jsx
+++ b/src/components/dataDisplays/cellRenderers/UserRenderer.jsx
@@ -1,14 +1,23 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { get } from 'lodash-es';
 import Link from '../../Link';
 
-export default function UserRenderer({
-  datum,
-  guidProperty = 'owner.guid',
-  nameProperty = 'owner.full_name',
-  fallbackName = 'Unnamed User',
-}) {
+function UserRenderer(
+  {
+    datum,
+    guidProperty = 'owner.guid',
+    nameProperty = 'owner.full_name',
+    fallbackName = 'Unnamed User',
+  },
+  ref,
+) {
   const userGuid = get(datum, guidProperty);
   const userName = get(datum, nameProperty, fallbackName);
-  return <Link href={`/users/${userGuid}`}>{userName}</Link>;
+  return (
+    <Link href={`/users/${userGuid}`} ref={ref}>
+      {userName}
+    </Link>
+  );
 }
+
+export default forwardRef(UserRenderer);

--- a/src/hooks/useActionsColumnWidth.js
+++ b/src/hooks/useActionsColumnWidth.js
@@ -1,0 +1,17 @@
+import { useTheme } from '@material-ui/core';
+
+// This returns a string meant to be used as a CSS width.
+// The values were determined by inspecting the resulting DOM elements.
+export default function useActionsColumnWidth(numberOfActions) {
+  const theme = useTheme();
+
+  const actionWidth = '1.5rem';
+  const totalActionPadding = `${numberOfActions *
+    theme.spacing(1)}px`;
+  const tableCellPadding = `${theme.spacing(4)}px`;
+  const actionLabelWidth = '73px';
+
+  const actionTdWidth = `calc(${numberOfActions} * ${actionWidth} + ${totalActionPadding} + ${tableCellPadding})`;
+  const actionThWidth = `calc(${actionLabelWidth} + ${tableCellPadding})`;
+  return `max(${actionTdWidth}, ${actionThWidth})`;
+}


### PR DESCRIPTION
This prevents the individual's sightings table cells from wrapping. When a cell's text overflows and a user hovers over the cell, a tooltip appears with the full cell value. For cells that have not overflowed, there is no tooltip.
<img width="714" alt="encounters-card-after" src="https://user-images.githubusercontent.com/50299119/164506273-2fd59e88-b934-4340-a861-396e296d83a1.png">

I updated all of the cell renderers instead of just the ones used by the EncountersCard in order to ensure that this design would work for them.

Hiding overflow required a sacrifice of the automatic table layout. For this table, I chose to let the Date column take a percentage of the space, let the Actions column take a fixed, calculated amount of space, and let the Location and Owner columns split the rest.

The actions cells do not have a `white-space: nowrap` style applied. However, they should not wrap because the calculation mentioned above should always provide enough width.
