### PR TITLE
DEX-939 restore missing bulk import fields

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -731,6 +731,7 @@
   "MARK_SIGHTING_REVIEWED_CONFIRMATION": "Are you sure you want to mark this sighting reviewed? This action cannot be undone.",
   "MATCH_COUNT": "{matchCount} {matchCount, plural, =0 {matches} one {match} other {matches}}",
   "PHOTO_COUNT": "{photoCount} {photoCount, plural, =0 {photographs} one {photograph} other {photographs}}",
+  "ENCOUNTERS_IMPORTED_COUNT": "{encounterCount} {encounterCount, plural, =0 {encounters} one {encounter} other {encounters}} imported.",
   "READY_FOR_REVIEW": "Ready for Identification Review",
   "CHANGE_PHOTO": "Change Photo",
   "1": "1",

--- a/src/pages/bulkImport/BulkReportForm.jsx
+++ b/src/pages/bulkImport/BulkReportForm.jsx
@@ -185,9 +185,12 @@ export default function BulkReportForm({ assetReferences }) {
             )}
           />
           {sightingData ? (
-            <Text variant="body2" style={{ margin: '8px 0 8px 4px' }}>
-              {`${sightingData.length} sightings imported.`}
-            </Text>
+            <Text
+              id="ENCOUNTERS_IMPORTED_COUNT"
+              values={{ encounterCount: sightingData.length }}
+              variant="body2"
+              style={{ margin: '8px 0 8px 4px' }}
+            />
           ) : null}
 
           {detectionModelField && (

--- a/src/pages/bulkImport/BulkReportForm.jsx
+++ b/src/pages/bulkImport/BulkReportForm.jsx
@@ -31,23 +31,23 @@ import {
 async function onRecordChange(record, recordIndex, filenames) {
   let messages = validateMinMax(record);
 
-  const individual = record?.individual;
-  if (individual) {
+  const firstName = record?.firstName;
+  if (firstName) {
     try {
       const nameValidationResponse = await validateIndividualNames([
-        [individual, recordIndex],
+        [firstName, recordIndex],
       ]);
       const nameMessage = get(nameValidationResponse, [0, 0]);
 
       if (nameMessage) {
         messages = {
           ...messages,
-          individual: nameMessage,
+          firstName: nameMessage,
         };
       }
     } catch (e) {
       console.error(
-        `Error validating individual name "${individual}" at ${recordIndex}`,
+        `Error validating individual name "${firstName}" at ${recordIndex}`,
         e,
       );
     }
@@ -161,7 +161,7 @@ export default function BulkReportForm({ assetReferences }) {
               setSightingData(results.data);
             }}
             fieldHooks={{
-              individual: async values => {
+              firstName: async values => {
                 try {
                   return await validateIndividualNames(values);
                 } catch (e) {

--- a/src/pages/bulkImport/constants/bulkReportConstants.js
+++ b/src/pages/bulkImport/constants/bulkReportConstants.js
@@ -5,7 +5,12 @@ export const bulkImportCategories = {
   },
   sighting: {
     name: 'sighting',
-    fields: ['sightingId', 'assetReferences', 'locationId'],
+    fields: [
+      'sightingId',
+      'assetReferences',
+      'locationId',
+      'comments',
+    ],
   },
   shared: {
     name: 'shared',

--- a/src/pages/bulkImport/constants/bulkReportConstants.js
+++ b/src/pages/bulkImport/constants/bulkReportConstants.js
@@ -5,7 +5,7 @@ export const bulkImportCategories = {
   },
   sighting: {
     name: 'sighting',
-    fields: ['sightingId', 'assets', 'locationId'],
+    fields: ['sightingId', 'assetReferences', 'locationId'],
   },
   shared: {
     name: 'shared',
@@ -50,5 +50,5 @@ export const bulkFieldSchemas = [
   { name: 'timeMinutes', labelId: 'TIME_MINUTES' },
   { name: 'timeSeconds', labelId: 'TIME_SECONDS' },
   { name: 'utcOffset', labelId: 'TIMEZONE' },
-  { name: 'assets', labelId: 'ASSETS' },
+  { name: 'assetReferences', labelId: 'ASSETS' },
 ];

--- a/src/pages/bulkImport/constants/bulkReportConstants.js
+++ b/src/pages/bulkImport/constants/bulkReportConstants.js
@@ -1,7 +1,7 @@
 export const bulkImportCategories = {
   encounter: {
     name: 'animal',
-    fields: ['individualName', 'taxonomy', 'sex'],
+    fields: ['firstName', 'taxonomy', 'sex'],
   },
   sighting: {
     name: 'sighting',
@@ -44,7 +44,7 @@ export const encounterOmitList = ['gps', 'specifiedTime'];
 export const bulkFieldSchemas = [
   { name: 'decimalLatitude', labelId: 'DECIMAL_LATITUDE' },
   { name: 'decimalLongitude', labelId: 'DECIMAL_LONGITUDE' },
-  { name: 'individualName', labelId: 'INDIVIDUAL_NAME' },
+  { name: 'firstName', labelId: 'INDIVIDUAL_NAME' },
   { name: 'locationId', labelId: 'REGION' },
   { name: 'timeSpecificity', labelId: 'SIGHTING_TIME_SPECIFICITY' },
   { name: 'sightingId', labelId: 'SIGHTING_ID' },

--- a/src/pages/bulkImport/utils/prepareAssetGroup.js
+++ b/src/pages/bulkImport/utils/prepareAssetGroup.js
@@ -36,7 +36,6 @@ export default function prepareAssetGroup(
   assetReferences,
 ) {
   const sightings = {};
-  const sightingTimeSpecificityTracker = {};
   const simpleAssetReferences = assetReferences.map(a => a.path);
   encounters.forEach(encounter => {
     const newEncounter = updateTimes(encounter);
@@ -89,14 +88,11 @@ export default function prepareAssetGroup(
       );
     }
 
-    if (!sightingTimeSpecificityTracker[sightingId]) {
-      assignIfPresent(
-        newEncounter,
-        sightings[sightingId],
-        'timeSpecificity',
-      );
-      sightingTimeSpecificityTracker[sightingId] = true;
-    }
+    assignIfPresent(
+      newEncounter,
+      sightings[sightingId],
+      'timeSpecificity',
+    );
 
     assignIfPresent(newEncounter, sightings[sightingId], 'time');
 

--- a/src/pages/bulkImport/utils/prepareAssetGroup.js
+++ b/src/pages/bulkImport/utils/prepareAssetGroup.js
@@ -98,17 +98,7 @@ export default function prepareAssetGroup(
       sightingTimeSpecificityTracker[sightingId] = true;
     }
 
-    const time = get(sightings, [sightingId, 'time']);
-    // const timeAfter = newEncounter.time < time; // removed for MVP, where we just take the first time and ignore the rest for the same sightingId
-    if (!time) {
-      // || timeAfter removed this condition for MVP, where we just take the first time and ignore the rest for the same sightingId
-      assignIfPresent(
-        newEncounter,
-        sightings[sightingId],
-        'time',
-        'time',
-      );
-    }
+    assignIfPresent(newEncounter, sightings[sightingId], 'time');
 
     if (!get(sightings, [sightingId, 'encounters']))
       sightings[sightingId].encounters = [];

--- a/src/pages/bulkImport/utils/prepareAssetGroup.js
+++ b/src/pages/bulkImport/utils/prepareAssetGroup.js
@@ -81,6 +81,14 @@ export default function prepareAssetGroup(
       'verbatimLocality',
     );
 
+    if (get(newEncounter, 'comments')) {
+      assignIfPresent(
+        newEncounter,
+        sightings[sightingId],
+        'comments',
+      );
+    }
+
     if (!sightingTimeSpecificityTracker[sightingId]) {
       assignIfPresent(
         newEncounter,
@@ -114,6 +122,7 @@ export default function prepareAssetGroup(
       'timeHour',
       'timeMinutes',
       'timeSeconds',
+      'comments',
     ]);
     sightings[sightingId].encounters.push(finalEncounter);
   });

--- a/src/pages/bulkImport/utils/useBulkImportFields.js
+++ b/src/pages/bulkImport/utils/useBulkImportFields.js
@@ -102,7 +102,7 @@ export default function useBulkImportFields() {
       label: intl.formatMessage({
         id: 'INDIVIDUAL_NAME',
       }),
-      key: 'individual',
+      key: 'firstName',
     },
     {
       label: intl.formatMessage({


### PR DESCRIPTION
# DEX-939
- Uses `assetReferences` as the key for assets in the bulk import workflow, which restores "Assets" to the available sighting fields list.
- Uses `firstName` as the key for individual names in the bulk import workflow, which restores "Individual Name" to the available animal fields list. I checked with BE and the key `firstName` on the `encounter` is the contract that is expected.
- Adds the sighting `comments` key to the bulkImportCategories sighting fields so that "Notes" correctly appears in the available sighting fields lists. Because it is possible for sighting comments to conflict in the spreadsheet entries, only the last comment that has a value for a given sighting is persisted to the sighting.

# Additional changes
- The last `time` and `timeSpecificity` for a given sighting are saved to that sighting instead of the first, in order to be consistent with the other fields.
- I changed the message that displays after a successful Flatfile submission from "{count} sightings imported." to "{count} encounters imported." to more accurately reflect what was imported.