### PR TITLE
DEX-944 - limit hot reloader to development environment

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { hot } from 'react-hot-loader/root';
 import { BrowserRouter, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 // import { ReactQueryDevtools } from 'react-query/devtools';
@@ -73,7 +74,7 @@ function AppWithQueryClient() {
   );
 }
 
-export default function App() {
+function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <AppWithQueryClient />
@@ -81,3 +82,7 @@ export default function App() {
     </QueryClientProvider>
   );
 }
+
+// react-hot-loader automatically ensures that it is not executed in production
+// and has a minimal footprint.
+export default hot(() => <App />);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,4 @@
-import { hot } from 'react-hot-loader/root'; // Needs to be imported before React
+import 'react-hot-loader/root'; // This needs to be imported before React.
 import React from 'react';
 import { render } from 'react-dom';
 import * as Sentry from '@sentry/react';
@@ -21,10 +21,6 @@ if (!__DEV__) {
 
 const root = document.getElementById('root');
 
-// react-hot-loader automatically ensures that it is not executed in production
-// and has a minimal footprint
-const Main = hot(() => <App />);
-
-const load = () => render(<Main />, root);
+const load = () => render(<App />, root);
 
 load();

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,6 @@
+import { hot } from 'react-hot-loader/root'; // Needs to be imported before React
 import React from 'react';
 import { render } from 'react-dom';
-import { hot } from 'react-hot-loader/root';
 import * as Sentry from '@sentry/react';
 import { get } from 'lodash-es';
 
@@ -21,6 +21,8 @@ if (!__DEV__) {
 
 const root = document.getElementById('root');
 
+// react-hot-loader automatically ensures that it is not executed in production
+// and has a minimal footprint
 const Main = hot(() => <App />);
 
 const load = () => render(<Main />, root);


### PR DESCRIPTION
- Adds comments about react-hot-loader being safe to use in a non-production environment.
- Moves react-hot-reloader's `hot` usage from `index` to `App` because of this warning:
<img width="693" alt="react-hot-loader-error" src="https://user-images.githubusercontent.com/50299119/165420221-03721dbd-a9b2-4cbc-9831-81011cc85d7a.png">