### PR TITLE
DEX-845 fix location render overflow

### DIFF
--- a/src/components/dataDisplays/cellRenderers/OverflowController.jsx
+++ b/src/components/dataDisplays/cellRenderers/OverflowController.jsx
@@ -8,6 +8,7 @@ const noWrapStyles = {
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
+  width: '100%',
 };
 
 export default function OverflowController({ title, children }) {


### PR DESCRIPTION
This reverts commit a6ded5a10ae99474c9f5c2c45dd4fb75034012f3: "Remove width of 100% from noWrapStyles"

- This style is required for LocationRenderer when lat and long exist

After this fix, the render controllers display like this. "Location renderer (detail)" is the one with latitude and longitude
<img width="690" alt="restore-width" src="https://user-images.githubusercontent.com/50299119/165656594-7c4af16c-88ac-4023-83ff-25e72ca39e20.png">
