### PR TITLE
DEX-940 bulk import custom field updates

### DIFF
--- a/src/pages/bulkImport/BulkFieldBreakdown.jsx
+++ b/src/pages/bulkImport/BulkFieldBreakdown.jsx
@@ -1,34 +1,17 @@
 import React from 'react';
-import { get } from 'lodash-es';
+import { startsWith } from 'lodash-es';
 import Paper from '@material-ui/core/Paper';
 
 import Text from '../../components/Text';
-import useEncounterFieldSchemas from '../../models/encounter/useEncounterFieldSchemas';
-import useSightingFieldSchemas from '../../models/sighting/useSightingFieldSchemas';
 import {
   bulkImportCategories,
-  bulkFieldSchemas,
+  deriveCustomFieldPrefix,
 } from './constants/bulkReportConstants';
+import categoryTypes from '../../constants/categoryTypes';
 
 const categories = Object.values(bulkImportCategories);
 
 export default function BulkFieldBreakdown({ availableFields }) {
-  const sightingFieldSchemas = useSightingFieldSchemas();
-  const encounterFieldSchemas = useEncounterFieldSchemas();
-  const sightingCustomFields = sightingFieldSchemas
-    .filter(schema => schema.customField)
-    .map(schema => schema.name);
-  const encounterCustomFields = encounterFieldSchemas
-    .filter(schema => schema.customField)
-    .map(schema => schema.name);
-  const schemas =
-    sightingFieldSchemas && encounterFieldSchemas
-      ? [
-          ...sightingFieldSchemas,
-          ...encounterFieldSchemas,
-          ...bulkFieldSchemas,
-        ]
-      : null;
   return (
     <Paper
       elevation={2}
@@ -51,12 +34,18 @@ export default function BulkFieldBreakdown({ availableFields }) {
             if (cat.fields.includes(f.key)) return true;
             if (
               cat.name === 'sighting' &&
-              sightingCustomFields.includes(f.key)
+              startsWith(
+                f.key,
+                deriveCustomFieldPrefix(categoryTypes.sighting),
+              )
             )
               return true;
             if (
-              cat.name === 'encounter' &&
-              encounterCustomFields.includes(f.key)
+              cat.name === 'animal' &&
+              startsWith(
+                f.key,
+                deriveCustomFieldPrefix(categoryTypes.encounter),
+              )
             )
               return true;
             return false;
@@ -64,18 +53,11 @@ export default function BulkFieldBreakdown({ availableFields }) {
           return (
             <div key={cat.name} style={{ marginRight: 120 }}>
               <Text variant="h6">{`${cat.name} fields`}</Text>
-              {fieldsInCategory.map(f => {
-                const fSchema = schemas.find(
-                  schema => schema.name === f.key,
-                );
-                const label = get(fSchema, 'label', f.key);
-                const labelId = get(fSchema, 'labelId');
-                return (
-                  <Text id={labelId} variant="body2" key={f.key}>
-                    {label}
-                  </Text>
-                );
-              })}
+              {fieldsInCategory.map(f => (
+                <Text variant="body2" key={f.key}>
+                  {f.label}
+                </Text>
+              ))}
             </div>
           );
         })}

--- a/src/pages/bulkImport/constants/bulkReportConstants.js
+++ b/src/pages/bulkImport/constants/bulkReportConstants.js
@@ -41,19 +41,6 @@ export const sightingOmitList = [
 /* Lat and lng are treated as two separate columns here */
 export const encounterOmitList = ['gps', 'specifiedTime'];
 
-export const bulkFieldSchemas = [
-  { name: 'decimalLatitude', labelId: 'DECIMAL_LATITUDE' },
-  { name: 'decimalLongitude', labelId: 'DECIMAL_LONGITUDE' },
-  { name: 'firstName', labelId: 'INDIVIDUAL_NAME' },
-  { name: 'locationId', labelId: 'REGION' },
-  { name: 'timeSpecificity', labelId: 'SIGHTING_TIME_SPECIFICITY' },
-  { name: 'sightingId', labelId: 'SIGHTING_ID' },
-  { name: 'timeYear', labelId: 'TIME_YEAR' },
-  { name: 'timeMonth', labelId: 'TIME_MONTH' },
-  { name: 'timeDay', labelId: 'TIME_DAY' },
-  { name: 'timeHour', labelId: 'TIME_HOUR' },
-  { name: 'timeMinutes', labelId: 'TIME_MINUTES' },
-  { name: 'timeSeconds', labelId: 'TIME_SECONDS' },
-  { name: 'utcOffset', labelId: 'TIMEZONE' },
-  { name: 'assetReferences', labelId: 'ASSETS' },
-];
+export function deriveCustomFieldPrefix(categoryType) {
+  return `custom-${categoryType}-`;
+}

--- a/src/pages/bulkImport/utils/useBulkImportFields.js
+++ b/src/pages/bulkImport/utils/useBulkImportFields.js
@@ -6,7 +6,9 @@ import useSightingFieldSchemas from '../../../models/sighting/useSightingFieldSc
 import {
   sightingOmitList,
   encounterOmitList,
+  deriveCustomFieldPrefix,
 } from '../constants/bulkReportConstants';
+import categoryTypes from '../../../constants/categoryTypes';
 import timePrecisionMap from '../../../constants/timePrecisionMap';
 import useOptions from '../../../hooks/useOptions';
 
@@ -41,6 +43,13 @@ function deriveLabel(field, intl) {
   return label || 'Label unavailable';
 }
 
+function deriveKey(field, categoryType) {
+  if (!field.customField) return field.name;
+
+  const prefix = deriveCustomFieldPrefix(categoryType);
+  return prefix + field.id;
+}
+
 export default function useBulkImportFields() {
   const intl = useIntl();
   const { regionOptions, speciesOptions } = useOptions();
@@ -60,7 +69,7 @@ export default function useBulkImportFields() {
         }
         return {
           label: deriveLabel(f, intl),
-          key: f.name,
+          key: deriveKey(f, categoryTypes.sighting),
           ...additionalProperties,
         };
       });
@@ -84,7 +93,7 @@ export default function useBulkImportFields() {
         }
         return {
           label: deriveLabel(f, intl),
-          key: f.name,
+          key: deriveKey(f, categoryTypes.encounter),
           ...additionalProperties,
         };
       });


### PR DESCRIPTION
This fixes two issues for custom fields used in bulk upload:
- It sets the Flatfile field key to a value that indicates if it is a setting or encounter field and includes the guid. I used `guid` instead of `name` because `name` is not necessarily unique for custom fields. The category type is required so that it can be parsed during data processing in order to assign the custom field to the correct category.
- It adds the custom fields to the sightings and encounters during data processing.
  - For a sighting, the custom fields that will be used are the values from the last row for that sighting that has any value for a custom sighting field.

For example, if you have the following spreadsheet, the sighting will have one custom field, "custom sighting field 2" with a value of "value 4"
| other columns | sighting ID | custom sighting field 1 | custom sighting field 2 | custom sighting field 3
| ---                    | :-:                | :-:                                   | :-:                                    | :-:
| ...                      | 1                 | value 1                            | value 2                            | value 3
| ...                      | 1                 |                                        | value 4                            |
| ...                      |  1                |                                         |                                         |
