### PR TITLE
DEX-945 update Flatfile props

### DIFF
--- a/src/pages/bulkImport/BulkReportForm.jsx
+++ b/src/pages/bulkImport/BulkReportForm.jsx
@@ -139,12 +139,11 @@ export default function BulkReportForm({ assetReferences }) {
           }}
         >
           <FlatfileButton
-            devMode
-            managed
-            maxRecords={1000}
             licenseKey={flatfileKey}
             customer={{ userId: 'dev' }}
             settings={{
+              devMode: __DEV__,
+              managed: true,
               disableManualInput: true,
               title: 'Import sightings data',
               type: 'bulk_import',


### PR DESCRIPTION
- Moves FlatfileButton `devMode` and `managed` props into the settings prop so that they work correctly.
  - `devMode` causes a banner to display at the top of the dialog.
  - `managed` adds additional file options. When managed is false, the file options are limited to .csv, .tsv, and .txt spreadsheets
- Sets devMode to true or false conditionally based on the `__DEV__` global variable.
- Removes the `maxRecords` prop instead of moving it to settings. Currently it is unknown how many encounters houston can handle, and the bulk import processing implementation is changing.

<img width="932" alt="after" src="https://user-images.githubusercontent.com/50299119/166001346-b3a809dd-8081-4522-9370-473c75a0de3a.png">

