### PR TITLE
Prevent useFetch setError when status is loading

### DIFF
--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -56,7 +56,13 @@ export default function useFetch({
   );
 
   const error = formatError(result);
-  useEffect(() => setDisplayedError(error), [error]);
+  useEffect(
+    () => {
+      if (result?.status === 'loading') return;
+      setDisplayedError(error);
+    },
+    [error, result?.status],
+  );
 
   return {
     ...result,


### PR DESCRIPTION
This is a quick fix to prevent the report page rendering in a React loop.