### PR TITLE
Dex 975 fill animal1 with manual annotation if none

### DIFF
--- a/src/components/AnnotationCreator.jsx
+++ b/src/components/AnnotationCreator.jsx
@@ -75,6 +75,8 @@ export default function AnnotationCreator({
   sightingData,
   pending,
 }) {
+  console.log('deleteMe sightingData is: ');
+  console.log(sightingData);
   const [viewpoint, setViewpoint] = useState('');
   const [IAClass, setIAClass] = useState('');
   const [rect, setRect] = useState({});

--- a/src/components/AnnotationCreator.jsx
+++ b/src/components/AnnotationCreator.jsx
@@ -44,7 +44,7 @@ async function getEncounterGuids(
     [],
   );
   const encountersWithNoAnnotations = filter(
-    get(sightingData, 'encounters'),
+    get(sightingData, 'encounters', []),
     encounter => get(encounter, 'annotations', []).length === 0,
     [],
   );

--- a/src/components/AnnotationCreator.jsx
+++ b/src/components/AnnotationCreator.jsx
@@ -48,13 +48,6 @@ async function getEncounterGuids(
     encounter => get(encounter, 'annotations', []).length === 0,
     [],
   );
-  console.log('deleteMe encountersWithNoAnnotations are:');
-  console.log(encountersWithNoAnnotations);
-  console.log(
-    'deleteMe encountersWithNoAnnotations.length > 0 is: ' +
-      encountersWithNoAnnotations.length >
-      0,
-  );
   if (encountersWithNoAnnotations.length > 0)
     return [get(encountersWithNoAnnotations, [0, 'guid'])];
   const encounterCreationResponse = await addEncounterToSighting({

--- a/src/components/AnnotationCreator.jsx
+++ b/src/components/AnnotationCreator.jsx
@@ -29,6 +29,8 @@ function percentageToPixels(percentValue, scalar) {
 }
 
 async function createEncounter(sightingData, addEncounterToSighting) {
+  console.log('deleteMe sightingData is: ');
+  console.log(sightingData);
   const copiedProperties = pick(sightingData, [
     'time',
     'timeSpecificity',

--- a/src/components/AnnotationCreator.jsx
+++ b/src/components/AnnotationCreator.jsx
@@ -51,6 +51,11 @@ async function getEncounterGuids(
   );
   console.log('deleteMe encountersWithNoAnnotations are:');
   console.log(encountersWithNoAnnotations);
+  console.log(
+    'deleteMe encountersWithNoAnnotations.length > 0 is: ' +
+      encountersWithNoAnnotations.length >
+      0,
+  );
   if (encountersWithNoAnnotations.length > 0)
     return [get(encountersWithNoAnnotations, [0, 'guid'])];
   const encounterCreationResponse = await addEncounterToSighting({

--- a/src/components/AnnotationCreator.jsx
+++ b/src/components/AnnotationCreator.jsx
@@ -32,8 +32,6 @@ async function getEncounterGuids(
   sightingData,
   addEncounterToSighting,
 ) {
-  console.log('deleteMe sightingData is: ');
-  console.log(sightingData);
   const copiedProperties = pick(sightingData, [
     'time',
     'timeSpecificity',
@@ -47,7 +45,8 @@ async function getEncounterGuids(
   );
   const encountersWithNoAnnotations = filter(
     get(sightingData, 'encounters'),
-    encounter => get(encounter, 'annotations', [].length === 0),
+    encounter => get(encounter, 'annotations', []).length === 0,
+    [],
   );
   console.log('deleteMe encountersWithNoAnnotations are:');
   console.log(encountersWithNoAnnotations);
@@ -91,8 +90,6 @@ export default function AnnotationCreator({
   sightingData,
   pending,
 }) {
-  console.log('deleteMe sightingData is: ');
-  console.log(sightingData);
   const [viewpoint, setViewpoint] = useState('');
   const [IAClass, setIAClass] = useState('');
   const [rect, setRect] = useState({});


### PR DESCRIPTION
Fixes the issue where if an annotation-less encounter already exists, a new encounter was being created anyway with the new manual annotation assigned to the latter.

With the fix, a new encounter is not created if an annotation-less encounter already exists, and the new manual annotation is assigned to the already-existing one instead. Only in the !pending case, of course.