### PR TITLE
Dex 937 twitter handle user data

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1053,5 +1053,6 @@
   "NOT_AUTHENTICATED_ERROR_SUBTITLE": "Authentication error",
   "NO_PERMISSIONS_ERROR_DETAILS": "You do not have permissions to access the requested resource.",
   "NOT_AUTHENTICATED_ERROR_DETAILS": "Your request could not be processed due to an authentication error. Log in and try again.",
-  "CONFIRM_REMOVE_RELATIONSHIP": "Are you sure you want to delete this relationship?"
+  "CONFIRM_REMOVE_RELATIONSHIP": "Are you sure you want to delete this relationship?",
+  "TWITTER_HANDLE": "Twitter handle"
 }

--- a/src/components/UserProfile.jsx
+++ b/src/components/UserProfile.jsx
@@ -35,8 +35,6 @@ export default function UserProfile({
   const intl = useIntl();
   const [editingProfile, setEditingProfile] = useState(false);
   const metadataSchemas = useUserMetadataSchemas(userId);
-  console.log('deleteMe metadataSchemas are: ');
-  console.log(metadataSchemas);
   const {
     data: agsData,
     loading: agsLoading,

--- a/src/components/UserProfile.jsx
+++ b/src/components/UserProfile.jsx
@@ -52,7 +52,7 @@ export default function UserProfile({
         )
         .map(schema => ({
           ...schema,
-          value: schema.getValue(schema, userData),
+          value: schema?.getValue(schema, userData),
         }));
     },
     [userData, metadataSchemas],

--- a/src/components/UserProfile.jsx
+++ b/src/components/UserProfile.jsx
@@ -46,13 +46,10 @@ export default function UserProfile({
     () => {
       if (!userData || !metadataSchemas) return [];
       return metadataSchemas
-        .filter(schema => {
-          console.log('deleteMe schema is: ');
-          console.log(schema);
-          console.log('deleteMe userData is: ');
-          console.log(userData);
-          return schema.getValue(schema, userData) || !someoneElse;
-        })
+        .filter(
+          schema =>
+            schema?.getValue(schema, userData) || !someoneElse,
+        )
         .map(schema => ({
           ...schema,
           value: schema.getValue(schema, userData),

--- a/src/components/UserProfile.jsx
+++ b/src/components/UserProfile.jsx
@@ -44,9 +44,13 @@ export default function UserProfile({
     () => {
       if (!userData || !metadataSchemas) return [];
       return metadataSchemas
-        .filter(
-          schema => schema.getValue(schema, userData) || !someoneElse,
-        )
+        .filter(schema => {
+          console.log('deleteMe schema is: ');
+          console.log(schema);
+          console.log('deleteMe userData is: ');
+          console.log(userData);
+          return schema.getValue(schema, userData) || !someoneElse;
+        })
         .map(schema => ({
           ...schema,
           value: schema.getValue(schema, userData),

--- a/src/components/UserProfile.jsx
+++ b/src/components/UserProfile.jsx
@@ -35,6 +35,8 @@ export default function UserProfile({
   const intl = useIntl();
   const [editingProfile, setEditingProfile] = useState(false);
   const metadataSchemas = useUserMetadataSchemas(userId);
+  console.log('deleteMe metadataSchemas are: ');
+  console.log(metadataSchemas);
   const {
     data: agsData,
     loading: agsLoading,

--- a/src/constants/intelligentAgentSchema.js
+++ b/src/constants/intelligentAgentSchema.js
@@ -1,6 +1,11 @@
+import TwitterIcon from '@material-ui/icons/Twitter';
+
 export const intelligentAgentSchema = [
   {
     platformName: 'twitter',
+    userMetadataKey: 'twitter_username',
+    userMetadataLabel: 'TWITTER_HANDLE',
+    icon: TwitterIcon,
     dividerLabel: 'TWITTER_SETTINGS',
     platformInformationLabel: 'TWITTER_API_KEYS_LABEL',
     platformInformationDescription: 'TWITTER_API_KEY_DESCRIPTION',

--- a/src/models/users/useUserMetadataSchemas.js
+++ b/src/models/users/useUserMetadataSchemas.js
@@ -50,6 +50,8 @@ export default function useUserMetadataSchemas(displayedUserId) {
             'data',
             'enablingField',
           ]);
+          console.log('deleteMe currentPlatformEnablingField is: ');
+          console.log(currentPlatformEnablingField);
           const isEnabled = get(siteSettings, [
             'data',
             currentPlatformEnablingField,
@@ -57,10 +59,20 @@ export default function useUserMetadataSchemas(displayedUserId) {
           ]);
           console.log('deleteMe isEnabled is: ');
           console.log(isEnabled);
+          const deleteMeSchema = createFieldSchema(
+            fieldTypes.string,
+            {
+              name: intelligentAgent?.userMetadataKey,
+              labelId: intelligentAgent?.userMetadataLabel,
+              icon: intelligentAgent?.icon,
+            },
+          );
+          console.log('deleteMe deleteMeSchema is: ');
+          console.log(deleteMeSchema);
           return isEnabled
             ? createFieldSchema(fieldTypes.string, {
-                name: intelligentAgent?.useMetadataKey,
-                labelId: intelligentAgent?.useMetadataLabel,
+                name: intelligentAgent?.userMetadataKey,
+                labelId: intelligentAgent?.userMetadataLabel,
                 icon: intelligentAgent?.icon,
               })
             : null;

--- a/src/models/users/useUserMetadataSchemas.js
+++ b/src/models/users/useUserMetadataSchemas.js
@@ -20,6 +20,10 @@ export default function useUserMetadataSchemas(displayedUserId) {
     'deleteMe siteSettings in useUserMetadataSchemas are: ',
   );
   console.log(siteSettings);
+  const isTwitterEnabled =
+    siteSettings?.data?.intelligent_agent_twitterbot_enabled?.value;
+  console.log('deleteMe isTwitterEnabled is: ');
+  console.log(isTwitterEnabled);
 
   const isAdmin = get(currentUserData, 'is_admin', false);
   const isCurrentUser =
@@ -35,6 +39,15 @@ export default function useUserMetadataSchemas(displayedUserId) {
               labelId: 'PROFILE_LABEL_EMAIL',
               icon: EmailIcon,
               viewComponent: EmailViewer,
+            }),
+          ]
+        : [];
+      const twitterFields = isTwitterEnabled
+        ? [
+            createFieldSchema(fieldTypes.string, {
+              name: 'twitter_username',
+              labelId: 'TWITTER_HANDLE',
+              icon: TwitterIcon,
             }),
           ]
         : [];
@@ -62,11 +75,7 @@ export default function useUserMetadataSchemas(displayedUserId) {
           labelId: 'PROFILE_LABEL_LOCATION',
           icon: LocationIcon,
         }),
-        createFieldSchema(fieldTypes.string, {
-          name: 'twitter_username',
-          labelId: 'TWITTER_HANDLE',
-          icon: TwitterIcon,
-        }),
+        ...twitterFields,
       ];
     },
     [isAdmin],

--- a/src/models/users/useUserMetadataSchemas.js
+++ b/src/models/users/useUserMetadataSchemas.js
@@ -4,7 +4,6 @@ import ForumIcon from '@material-ui/icons/Forum';
 import EmailIcon from '@material-ui/icons/Email';
 import LocationIcon from '@material-ui/icons/PersonPin';
 import AffiliationIcon from '@material-ui/icons/AccountBalance';
-// import TwitterIcon from '@material-ui/icons/Twitter'; //deleteMe
 
 import useGetMe from './useGetMe';
 import useSiteSettings from '../site/useSiteSettings';
@@ -17,14 +16,6 @@ import ForumIdViewer from '../../components/fields/view/ForumIdViewer';
 export default function useUserMetadataSchemas(displayedUserId) {
   const { data: currentUserData, loading, error } = useGetMe();
   const siteSettings = useSiteSettings();
-  console.log(
-    'deleteMe siteSettings in useUserMetadataSchemas are: ',
-  );
-  console.log(siteSettings);
-  const isTwitterEnabled =
-    siteSettings?.data?.intelligent_agent_twitterbot_enabled?.value;
-  console.log('deleteMe isTwitterEnabled is: ');
-  console.log(isTwitterEnabled);
 
   const isAdmin = get(currentUserData, 'is_admin', false);
   const isCurrentUser =
@@ -50,8 +41,6 @@ export default function useUserMetadataSchemas(displayedUserId) {
             'data',
             'enablingField',
           ]);
-          console.log('deleteMe currentPlatformEnablingField is: ');
-          console.log(currentPlatformEnablingField);
           const isEnabled = get(siteSettings, [
             'data',
             currentPlatformEnablingField,

--- a/src/models/users/useUserMetadataSchemas.js
+++ b/src/models/users/useUserMetadataSchemas.js
@@ -57,18 +57,6 @@ export default function useUserMetadataSchemas(displayedUserId) {
             currentPlatformEnablingField,
             'value',
           ]);
-          console.log('deleteMe isEnabled is: ');
-          console.log(isEnabled);
-          const deleteMeSchema = createFieldSchema(
-            fieldTypes.string,
-            {
-              name: intelligentAgent?.userMetadataKey,
-              labelId: intelligentAgent?.userMetadataLabel,
-              icon: intelligentAgent?.icon,
-            },
-          );
-          console.log('deleteMe deleteMeSchema is: ');
-          console.log(deleteMeSchema);
           return isEnabled
             ? createFieldSchema(fieldTypes.string, {
                 name: intelligentAgent?.userMetadataKey,
@@ -79,17 +67,6 @@ export default function useUserMetadataSchemas(displayedUserId) {
         },
         [],
       );
-      console.log('deleteMe intelligentAgentFields are: ');
-      console.log(intelligentAgentFields);
-      // const twitterFields = isTwitterEnabled
-      //   ? [
-      //       createFieldSchema(fieldTypes.string, {
-      //         name: 'twitter_username',
-      //         labelId: 'TWITTER_HANDLE',
-      //         icon: TwitterIcon,
-      //       }),
-      //     ]
-      //   : [];
 
       return [
         createFieldSchema(fieldTypes.string, {

--- a/src/models/users/useUserMetadataSchemas.js
+++ b/src/models/users/useUserMetadataSchemas.js
@@ -4,8 +4,10 @@ import ForumIcon from '@material-ui/icons/Forum';
 import EmailIcon from '@material-ui/icons/Email';
 import LocationIcon from '@material-ui/icons/PersonPin';
 import AffiliationIcon from '@material-ui/icons/AccountBalance';
+import TwitterIcon from '@material-ui/icons/Twitter';
 
 import useGetMe from './useGetMe';
+import useSiteSettings from '../site/useSiteSettings';
 import fieldTypes from '../../constants/fieldTypesNew';
 import { createFieldSchema } from '../../utils/fieldUtils';
 import EmailViewer from '../../components/fields/view/EmailViewer';
@@ -13,6 +15,11 @@ import ForumIdViewer from '../../components/fields/view/ForumIdViewer';
 
 export default function useUserMetadataSchemas(displayedUserId) {
   const { data: currentUserData, loading, error } = useGetMe();
+  const siteSettings = useSiteSettings();
+  console.log(
+    'deleteMe siteSettings in useUserMetadataSchemas are: ',
+  );
+  console.log(siteSettings);
 
   const isAdmin = get(currentUserData, 'is_admin', false);
   const isCurrentUser =
@@ -54,6 +61,11 @@ export default function useUserMetadataSchemas(displayedUserId) {
           name: 'location',
           labelId: 'PROFILE_LABEL_LOCATION',
           icon: LocationIcon,
+        }),
+        createFieldSchema(fieldTypes.string, {
+          name: 'twitter_username',
+          labelId: 'TWITTER_HANDLE',
+          icon: TwitterIcon,
         }),
       ];
     },

--- a/src/models/users/useUserMetadataSchemas.js
+++ b/src/models/users/useUserMetadataSchemas.js
@@ -1,15 +1,16 @@
 import { useMemo } from 'react';
-import { get } from 'lodash-es';
+import { get, map } from 'lodash-es';
 import ForumIcon from '@material-ui/icons/Forum';
 import EmailIcon from '@material-ui/icons/Email';
 import LocationIcon from '@material-ui/icons/PersonPin';
 import AffiliationIcon from '@material-ui/icons/AccountBalance';
-import TwitterIcon from '@material-ui/icons/Twitter';
+// import TwitterIcon from '@material-ui/icons/Twitter'; //deleteMe
 
 import useGetMe from './useGetMe';
 import useSiteSettings from '../site/useSiteSettings';
 import fieldTypes from '../../constants/fieldTypesNew';
 import { createFieldSchema } from '../../utils/fieldUtils';
+import { intelligentAgentSchema } from '../../constants/intelligentAgentSchema';
 import EmailViewer from '../../components/fields/view/EmailViewer';
 import ForumIdViewer from '../../components/fields/view/ForumIdViewer';
 
@@ -42,15 +43,41 @@ export default function useUserMetadataSchemas(displayedUserId) {
             }),
           ]
         : [];
-      const twitterFields = isTwitterEnabled
-        ? [
-            createFieldSchema(fieldTypes.string, {
-              name: 'twitter_username',
-              labelId: 'TWITTER_HANDLE',
-              icon: TwitterIcon,
-            }),
-          ]
-        : [];
+      const intelligentAgentFields = map(
+        intelligentAgentSchema,
+        intelligentAgent => {
+          const currentPlatformEnablingField = get(intelligentAgent, [
+            'data',
+            'enablingField',
+          ]);
+          const isEnabled = get(siteSettings, [
+            'data',
+            currentPlatformEnablingField,
+            'value',
+          ]);
+          console.log('deleteMe isEnabled is: ');
+          console.log(isEnabled);
+          return isEnabled
+            ? createFieldSchema(fieldTypes.string, {
+                name: intelligentAgent?.useMetadataKey,
+                labelId: intelligentAgent?.useMetadataLabel,
+                icon: intelligentAgent?.icon,
+              })
+            : null;
+        },
+        [],
+      );
+      console.log('deleteMe intelligentAgentFields are: ');
+      console.log(intelligentAgentFields);
+      // const twitterFields = isTwitterEnabled
+      //   ? [
+      //       createFieldSchema(fieldTypes.string, {
+      //         name: 'twitter_username',
+      //         labelId: 'TWITTER_HANDLE',
+      //         icon: TwitterIcon,
+      //       }),
+      //     ]
+      //   : [];
 
       return [
         createFieldSchema(fieldTypes.string, {
@@ -75,10 +102,10 @@ export default function useUserMetadataSchemas(displayedUserId) {
           labelId: 'PROFILE_LABEL_LOCATION',
           icon: LocationIcon,
         }),
-        ...twitterFields,
+        ...intelligentAgentFields,
       ];
     },
-    [isAdmin],
+    [isAdmin, siteSettings],
   );
 
   if (loading || error) return null;

--- a/src/pages/generalSettings/GeneralSettings.jsx
+++ b/src/pages/generalSettings/GeneralSettings.jsx
@@ -299,6 +299,7 @@ export default function GeneralSettings() {
           )}
           <Button
             onClick={() => {
+              setShowTwitterSuccess(false);
               /* Prepare custom fields objects to send to backend */
               Object.values(customFields).forEach(customFieldKey => {
                 const fields = currentValues[customFieldKey];

--- a/src/pages/generalSettings/GeneralSettings.jsx
+++ b/src/pages/generalSettings/GeneralSettings.jsx
@@ -106,6 +106,10 @@ export default function GeneralSettings() {
 
   useEffect(
     () => {
+      console.log('deleteMe twitterStatusCode is: ');
+      console.log(twitterStatusCode);
+      console.log('deleteMe twitterTestResults are: ');
+      console.log(twitterTestResults);
       setShowTwitterSuccess(twitterTestResults?.success);
     },
     [twitterTestResults, twitterStatusCode],
@@ -299,7 +303,6 @@ export default function GeneralSettings() {
           )}
           <Button
             onClick={() => {
-              setShowTwitterSuccess(false);
               /* Prepare custom fields objects to send to backend */
               Object.values(customFields).forEach(customFieldKey => {
                 const fields = currentValues[customFieldKey];

--- a/src/pages/generalSettings/GeneralSettings.jsx
+++ b/src/pages/generalSettings/GeneralSettings.jsx
@@ -110,7 +110,11 @@ export default function GeneralSettings() {
       console.log(twitterStatusCode);
       console.log('deleteMe twitterTestResults are: ');
       console.log(twitterTestResults);
-      setShowTwitterSuccess(twitterTestResults?.success);
+      setShowTwitterSuccess(
+        twitterStatusCode !== 400
+          ? twitterTestResults?.success
+          : false,
+      );
     },
     [twitterTestResults, twitterStatusCode],
   );

--- a/src/pages/generalSettings/GeneralSettings.jsx
+++ b/src/pages/generalSettings/GeneralSettings.jsx
@@ -106,10 +106,6 @@ export default function GeneralSettings() {
 
   useEffect(
     () => {
-      console.log('deleteMe twitterStatusCode is: ');
-      console.log(twitterStatusCode);
-      console.log('deleteMe twitterTestResults are: ');
-      console.log(twitterTestResults);
       setShowTwitterSuccess(
         twitterStatusCode !== 400
           ? twitterTestResults?.success

--- a/src/pages/generalSettings/IntelligentAgentSettings.jsx
+++ b/src/pages/generalSettings/IntelligentAgentSettings.jsx
@@ -91,15 +91,21 @@ export default function IntelligentAgentSettings({
             skipDescription={enabledSkipDescription}
           />
           <DividerTitle
+            key={get(intelligentAgent, 'dividerLabel')}
             titleId={get(intelligentAgent, 'dividerLabel')}
             style={{ marginTop: 32 }}
           />
           <Text
+            key={get(intelligentAgent, 'platformInformationLabel')}
             style={{ marginTop: 20 }}
             variant="subtitle1"
             id={get(intelligentAgent, 'platformInformationLabel')}
           />
           <Text
+            key={get(
+              intelligentAgent,
+              'platformInformationDescription',
+            )}
             style={{ marginTop: 4 }}
             variant="body2"
             id={get(
@@ -109,11 +115,16 @@ export default function IntelligentAgentSettings({
             values={{
               documentationLink: (
                 <Link
+                  key={get(intelligentAgent, 'apiDocumentationUrl')}
                   newTab
                   external
                   href={get(intelligentAgent, 'apiDocumentationUrl')}
                 >
                   <FormattedMessage
+                    key={get(
+                      intelligentAgent,
+                      'apiDocumentationUrlLabel',
+                    )}
                     id={get(
                       intelligentAgent,
                       'apiDocumentationUrlLabel',


### PR DESCRIPTION
schema.getValue → schema?.getValue in a few places, because it was breaking as soon as the user had a twitter handle but the twitterbot was disabled.

Added new data to the intelligentAgentSchema pertaining to user metadata.

Improved the setShowTwitterSuccess logic to be more robust to differences in the twitterStatusCode output vs the twitterTestResults output (and yes, the do disagree sometimes, resulting e.g. in situations where the status code is 400 but the test results still show success as true).

Added keys to IntelligentAgentSettings to make the warnings go away.

