### PR TITLE
Disable kickoff annotation UI

### DIFF
--- a/src/pages/sighting/MoreAnnotationMenu.jsx
+++ b/src/pages/sighting/MoreAnnotationMenu.jsx
@@ -7,10 +7,10 @@ import MenuItem from '@material-ui/core/MenuItem';
 export default function MoreAnnotationMenu({
   id,
   anchorEl,
-  pending,
+  // pending,
   open,
   onClose,
-  onClickStartIdentification = Function.prototype,
+  // onClickStartIdentification = Function.prototype,
   // onClickEditAnnotation = Function.prototype,
   onClickDelete = Function.prototype,
 }) {
@@ -19,12 +19,12 @@ export default function MoreAnnotationMenu({
       {/* <MenuItem onClick={onClickEditAnnotation}>
         <FormattedMessage id="EDIT_ANNOTATION" />
       </MenuItem> */}
-      <MenuItem
+      {/* <MenuItem
         disabled={pending}
         onClick={onClickStartIdentification}
       >
         <FormattedMessage id="START_IDENTIFICATION" />
-      </MenuItem>
+      </MenuItem> */}
       <MenuItem onClick={onClickDelete}>
         <FormattedMessage id="DELETE_ANNOTATION" />
       </MenuItem>


### PR DESCRIPTION
Not removing the whole UI because I expect this functionality to be restored soon