### PR TITLE
dex-1058 remove uppy/tus local fingerprint

### DIFF
--- a/src/hooks/useReportUppyInstance.js
+++ b/src/hooks/useReportUppyInstance.js
@@ -29,6 +29,7 @@ export default function useReportUppyInstance(reportType) {
       headers: {
         'x-tus-transaction-id': assetSubmissionId,
       },
+      removeFingerprintOnSuccess: true,
     });
 
     uppyInstance.on('upload', () => setUploadInProgress(true));


### PR DESCRIPTION
Uppy/Tus (via tus-js-client) saves a fingerprint to local storage so that an interrupted file upload can be resumed. 

Removing the fingerprint after a successful upload will prevent the extra HEAD requests from being made, failing, and displaying in the console.