### PR TITLE
dex 989 - send delete request for removed file

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "react-query": "^3.34.1",
     "react-router-hash-link": "^2.4.3",
     "react-transition-group": "^4.4.1",
-    "uuid": "^3.4.0",
+    "uuid": "^8.3.2",
     "webpack-version-file": "^0.1.6"
   }
 }

--- a/src/components/settings/MediaViewer.jsx
+++ b/src/components/settings/MediaViewer.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactPlayer from 'react-player';
-import { v4 as uuid } from 'uuid';
 import Paper from '@material-ui/core/Paper';
 import VideoIcon from '@material-ui/icons/Movie';
 

--- a/src/hooks/useReportUppyInstance.js
+++ b/src/hooks/useReportUppyInstance.js
@@ -33,72 +33,75 @@ export default function useReportUppyInstance(reportType) {
   const fileRef = useRef([]);
   fileRef.current = files;
 
-  useEffect(() => {
-    const uppyInstance = new Uppy({
-      meta: { type: reportType },
-      restrictions: {
-        allowedFileTypes: ['.jpg', '.jpeg', '.png'],
-      },
-      autoProceed: true,
-    });
+  useEffect(
+    () => {
+      const uppyInstance = new Uppy({
+        meta: { type: reportType },
+        restrictions: {
+          allowedFileTypes: ['.jpg', '.jpeg', '.png'],
+        },
+        autoProceed: true,
+      });
 
-    uppyInstance.use(Tus, {
-      endpoint: `${__houston_url__}/api/v1/tus`,
-      headers: {
-        'x-tus-transaction-id': assetSubmissionId,
-      },
-      removeFingerprintOnSuccess: true,
-    });
+      uppyInstance.use(Tus, {
+        endpoint: `${__houston_url__}/api/v1/tus`,
+        headers: {
+          'x-tus-transaction-id': assetSubmissionId,
+        },
+        removeFingerprintOnSuccess: true,
+      });
 
-    uppyInstance.on('upload', () => setUploadInProgress(true));
+      uppyInstance.on('upload', () => setUploadInProgress(true));
 
-    uppyInstance.on('complete', uppyState => {
-      const uploadObjects = get(uppyState, 'successful', []);
-      const assetReferences = uploadObjects.map(o => ({
-        path: o.name,
-        transactionId: assetSubmissionId,
-      }));
+      uppyInstance.on('complete', uppyState => {
+        const uploadObjects = get(uppyState, 'successful', []);
+        const assetReferences = uploadObjects.map(o => ({
+          path: o.name,
+          transactionId: assetSubmissionId,
+        }));
 
-      setUploadInProgress(false);
-      setFiles([...fileRef.current, ...assetReferences]);
-    });
+        setUploadInProgress(false);
+        setFiles([...fileRef.current, ...assetReferences]);
+      });
 
-    uppyInstance.on('file-removed', async (file, reason) => {
-      if (reason === 'removed-by-user') {
-        const uploadUrl = file?.response?.uploadURL;
-        try {
-          const fileGuid = parseFileGuidFromUploadUrl(uploadUrl);
-          await axios.delete(
-            `${__houston_url__}/api/v1/tus/${fileGuid}`,
-            {
-              headers: {
-                'x-tus-transaction-id': assetSubmissionId,
+      uppyInstance.on('file-removed', async (file, reason) => {
+        if (reason === 'removed-by-user') {
+          const uploadUrl = file?.response?.uploadURL;
+          try {
+            const fileGuid = parseFileGuidFromUploadUrl(uploadUrl);
+            await axios.delete(
+              `${__houston_url__}/api/v1/tus/${fileGuid}`,
+              {
+                headers: {
+                  'x-tus-transaction-id': assetSubmissionId,
+                },
               },
-            },
+            );
+          } catch (error) {
+            let errorMessage = `${error.name || 'Error'} deleting ${
+              file.name
+            }.`;
+
+            if (error.message) errorMessage += ` ${error.message}`;
+
+            console.error(errorMessage);
+          }
+
+          const newFiles = fileRef.current.filter(
+            f => f.path !== file.name,
           );
-        } catch (error) {
-          let errorMessage = `${error.name || 'Error'} deleting ${
-            file.name
-          }.`;
-
-          if (error.message) errorMessage += ` ${error.message}`;
-
-          console.error(errorMessage);
+          setFiles(newFiles);
         }
+      });
 
-        const newFiles = fileRef.current.filter(
-          f => f.path !== file.name,
-        );
-        setFiles(newFiles);
-      }
-    });
+      setUppy(uppyInstance);
 
-    setUppy(uppyInstance);
-
-    return () => {
-      if (uppyInstance) uppyInstance.close();
-    };
-  }, []);
+      return () => {
+        if (uppyInstance) uppyInstance.close();
+      };
+    },
+    [reportType, assetSubmissionId],
+  );
 
   return {
     uppy,

--- a/src/hooks/useReportUppyInstance.js
+++ b/src/hooks/useReportUppyInstance.js
@@ -1,8 +1,26 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { v4 as uuid } from 'uuid';
+import { v4 as uuid, validate as uuidValidate } from 'uuid';
 import Tus from '@uppy/tus';
 import Uppy from '@uppy/core';
 import { get } from 'lodash-es';
+import axios from 'axios';
+
+function parseFileGuidFromUploadUrl(uploadUrl) {
+  if (!uploadUrl) throw new Error('Missing upload URL');
+
+  const potentialResourceGuid = uploadUrl
+    .split('/')
+    .filter(token => token)
+    .pop();
+
+  if (!uuidValidate(potentialResourceGuid)) {
+    throw new Error(
+      `Upload URL, ${uploadUrl}, has an invalid resource GUID, "${potentialResourceGuid}".`,
+    );
+  }
+
+  return potentialResourceGuid;
+}
 
 export default function useReportUppyInstance(reportType) {
   const [uppy, setUppy] = useState(null);
@@ -45,8 +63,29 @@ export default function useReportUppyInstance(reportType) {
       setFiles([...fileRef.current, ...assetReferences]);
     });
 
-    uppyInstance.on('file-removed', (file, reason) => {
+    uppyInstance.on('file-removed', async (file, reason) => {
       if (reason === 'removed-by-user') {
+        const uploadUrl = file?.response?.uploadURL;
+        try {
+          const fileGuid = parseFileGuidFromUploadUrl(uploadUrl);
+          await axios.delete(
+            `${__houston_url__}/api/v1/tus/${fileGuid}`,
+            {
+              headers: {
+                'x-tus-transaction-id': assetSubmissionId,
+              },
+            },
+          );
+        } catch (error) {
+          let errorMessage = `${error.name || 'Error'} deleting ${
+            file.name
+          }.`;
+
+          if (error.message) errorMessage += ` ${error.message}`;
+
+          console.error(errorMessage);
+        }
+
         const newFiles = fileRef.current.filter(
           f => f.path !== file.name,
         );


### PR DESCRIPTION
- Sends a delete request when a file is removed from the Uppy dashboard on the Report a Sighting or Bulk Import page.
  - Updates the `uuid` package in order to get access to the new `validate` function
  - If there is an error with the deletion, the error message is logged to the console. I had originally alerted the user to the error, but decided against it because there is no recovery action that they can take, and when we submit the sighting we only include the asset references stored in client memory.

The houston changes for this functionality are in wildmeorg/houston#631