### PR TITLE
Dex 665 show default custom values

### DIFF
--- a/src/components/cards/MetadataCard.jsx
+++ b/src/components/cards/MetadataCard.jsx
@@ -21,7 +21,12 @@ function fieldValueGood(field) {
   console.log('deleteMe and its value is: ');
   console.log(value);
   if (badValues.includes(value)) return false;
-  if (Array.isArray(value) && value?.length < 1) return false;
+  if (Array.isArray(value)) {
+    if (value?.length < 1) return false;
+    const removeNulls = value.filter(entry => entry !== null); //for lat/long
+    if (removeNulls?.length < 1) return false;
+  }
+
   if (value?.time === null && value?.timeSpecificity === null)
     return false;
   return true;

--- a/src/components/cards/MetadataCard.jsx
+++ b/src/components/cards/MetadataCard.jsx
@@ -27,7 +27,7 @@ export default function MetadataCard({
   titleId = 'METADATA',
   metadata,
   editable = false,
-  showDefaultValues = false,
+  showDefaultValues = true,
   editButtonId = 'REPORT_METADATA',
   onEdit,
 }) {

--- a/src/components/cards/MetadataCard.jsx
+++ b/src/components/cards/MetadataCard.jsx
@@ -15,9 +15,13 @@ import Card from './Card';
 
 const badValues = [null, undefined, ''];
 function fieldValueGood(field) {
+  console.log('deleteMe field in fieldValueGood is: ');
+  console.log(field);
   const value = field?.value;
+  console.log('deleteMe and its value is: ');
+  console.log(value);
   if (badValues.includes(value)) return false;
-  if (value.isArray && value?.length < 1) return false;
+  if (Array.isArray(value) && value?.length < 1) return false;
   if (value?.time === null && value?.timeSpecificity === null)
     return false;
   return true;

--- a/src/components/cards/MetadataCard.jsx
+++ b/src/components/cards/MetadataCard.jsx
@@ -17,6 +17,7 @@ const badValues = [null, undefined, ''];
 function fieldValueGood(field) {
   const value = field?.value;
   if (badValues.includes(value)) return false;
+  if (value.isArray && value?.length < 1) return false;
   if (value?.time === null && value?.timeSpecificity === null)
     return false;
   return true;

--- a/src/components/cards/MetadataCard.jsx
+++ b/src/components/cards/MetadataCard.jsx
@@ -32,11 +32,17 @@ export default function MetadataCard({
   onEdit,
 }) {
   const metadataToDisplay = metadata.filter(field => {
+    console.log('deleteMe current field is: ');
+    console.log(field);
     const valid = !field?.hideInMetadataCard && fieldValueGood(field);
+    console.log('deleteMe valid is: ');
+    console.log(valid);
     const passedDefaultValueCheck = showDefaultValues
       ? true
       : JSON.stringify(field?.value) !==
         JSON.stringify(field?.defaultValue);
+    console.log('deleteMe passedDefaultValueCheck is: ');
+    console.log(passedDefaultValueCheck);
     return valid && passedDefaultValueCheck;
   });
 
@@ -64,8 +70,6 @@ export default function MetadataCard({
       <List dense>
         {metadata
           ? metadataToDisplay.map(field => {
-              console.log('deleteMe current field is: ');
-              console.log(field);
               const viewComponentProps =
                 field?.viewComponentProps || {};
 

--- a/src/components/cards/MetadataCard.jsx
+++ b/src/components/cards/MetadataCard.jsx
@@ -64,6 +64,8 @@ export default function MetadataCard({
       <List dense>
         {metadata
           ? metadataToDisplay.map(field => {
+              console.log('deleteMe current field is: ');
+              console.log(field);
               const viewComponentProps =
                 field?.viewComponentProps || {};
 

--- a/src/components/cards/MetadataCard.jsx
+++ b/src/components/cards/MetadataCard.jsx
@@ -23,7 +23,7 @@ function fieldValueGood(field) {
   if (badValues.includes(value)) return false;
   if (Array.isArray(value)) {
     if (value?.length < 1) return false;
-    const removeNulls = value.filter(entry => entry !== null); //for lat/long
+    const removeNulls = value.filter(entry => entry !== null); //for lat/long, although a legit 0,0 lat/long comes back as [null, null] currently, so it'll be a blindspot for us.
     if (removeNulls?.length < 1) return false;
   }
 

--- a/src/components/cards/MetadataCard.jsx
+++ b/src/components/cards/MetadataCard.jsx
@@ -15,15 +15,11 @@ import Card from './Card';
 
 const badValues = [null, undefined, ''];
 function fieldValueGood(field) {
-  console.log('deleteMe field in fieldValueGood is: ');
-  console.log(field);
   const value = field?.value;
-  console.log('deleteMe and its value is: ');
-  console.log(value);
   if (badValues.includes(value)) return false;
   if (Array.isArray(value)) {
     if (value?.length < 1) return false;
-    const removeNulls = value.filter(entry => entry !== null); //for lat/long, although a legit 0,0 lat/long comes back as [null, null] currently, so it'll be a blindspot for us.
+    const removeNulls = value.filter(entry => entry !== null);
     if (removeNulls?.length < 1) return false;
   }
 
@@ -42,17 +38,11 @@ export default function MetadataCard({
   onEdit,
 }) {
   const metadataToDisplay = metadata.filter(field => {
-    console.log('deleteMe current field is: ');
-    console.log(field);
     const valid = !field?.hideInMetadataCard && fieldValueGood(field);
-    console.log('deleteMe valid is: ');
-    console.log(valid);
     const passedDefaultValueCheck = showDefaultValues
       ? true
       : JSON.stringify(field?.value) !==
         JSON.stringify(field?.defaultValue);
-    console.log('deleteMe passedDefaultValueCheck is: ');
-    console.log(passedDefaultValueCheck);
     return valid && passedDefaultValueCheck;
   });
 

--- a/src/utils/fieldUtils.js
+++ b/src/utils/fieldUtils.js
@@ -190,7 +190,6 @@ export function createCustomFieldSchema(houstonSchema) {
         ['customFields', schema.id],
         get(schema, 'defaultValue', null),
       ),
-    // hideInMetadataCard: false,
   };
 
   const defaultValue = get(houstonSchema, 'default');

--- a/src/utils/fieldUtils.js
+++ b/src/utils/fieldUtils.js
@@ -190,7 +190,7 @@ export function createCustomFieldSchema(houstonSchema) {
         ['customFields', schema.id],
         get(schema, 'defaultValue', null),
       ),
-    hideInMetadataCard: false,
+    // hideInMetadataCard: false,
   };
 
   const defaultValue = get(houstonSchema, 'default');

--- a/src/utils/fieldUtils.js
+++ b/src/utils/fieldUtils.js
@@ -190,6 +190,7 @@ export function createCustomFieldSchema(houstonSchema) {
         ['customFields', schema.id],
         get(schema, 'defaultValue', null),
       ),
+    hideInMetadataCard: false,
   };
 
   const defaultValue = get(houstonSchema, 'default');


### PR DESCRIPTION
Default values for custom fields were not being displayed. Now, they are:
<img width="1312" alt="Screen Shot 2022-05-24 at 3 54 13 PM" src="https://user-images.githubusercontent.com/2775448/170144934-c57d3d2b-2f0c-470a-ad0b-0717de976347.png">

