### PR TITLE
Send re-run Id request

### DIFF
--- a/src/components/cards/EncountersCard.jsx
+++ b/src/components/cards/EncountersCard.jsx
@@ -159,6 +159,7 @@ export default function EncountersCard({
       )}
       {!noEncounters && !showMapView && (
         <DataDisplay
+          idKey="guid"
           noTitleBar
           tableSize="medium"
           columns={filteredColumns}

--- a/src/models/sighting/useRunIdOnSighting.js
+++ b/src/models/sighting/useRunIdOnSighting.js
@@ -1,0 +1,13 @@
+import { usePost } from '../../hooks/useMutate';
+import { getSightingQueryKey } from '../../constants/queryKeys';
+
+export default function useRunIdOnSighting() {
+  return usePost({
+    deriveUrl: ({ sightingGuid }) =>
+      `/sightings/${sightingGuid}/rerun_id`,
+    deriveData: ({ data }) => data,
+    deriveFetchKeys: ({ sightingGuid }) => [
+      getSightingQueryKey(sightingGuid),
+    ],
+  });
+}

--- a/src/pages/sighting/SightingEntityHeader.jsx
+++ b/src/pages/sighting/SightingEntityHeader.jsx
@@ -15,6 +15,7 @@ import FeaturedPhoto from '../../components/FeaturedPhoto';
 import { formatDateCustom } from '../../utils/formatters';
 import timePrecisionMap from '../../constants/timePrecisionMap';
 import defaultSightingSrc from '../../assets/defaultSighting.png';
+import RerunIdentificationDialog from './identification/RerunIdentificationDialog';
 
 const tabItems = [
   {
@@ -47,6 +48,7 @@ export default function SightingEntityHeader({
   const intl = useIntl();
 
   const [reviewDialogOpen, setReviewDialogOpen] = useState(false);
+  const [rerunDialogOpen, setRerunDialogOpen] = useState(false);
 
   const sightingIsReviewed = Boolean(data?.review_time);
 
@@ -91,6 +93,11 @@ export default function SightingEntityHeader({
         open={reviewDialogOpen}
         onClose={() => setReviewDialogOpen(false)}
       />
+      <RerunIdentificationDialog
+        sightingGuid={guid}
+        open={rerunDialogOpen}
+        onClose={() => setRerunDialogOpen(false)}
+      />
       <EntityHeader
         renderAvatar={
           <FeaturedPhoto
@@ -129,6 +136,12 @@ export default function SightingEntityHeader({
                   onClick: () => setReviewDialogOpen(true),
                   disabled: pending || sightingIsReviewed,
                   label: 'Mark sighting reviewed',
+                },
+                {
+                  id: 'rerun-identification',
+                  onClick: () => setRerunDialogOpen(true),
+                  disabled: pending,
+                  label: 'Re-run identification',
                 },
                 {
                   id: 'delete-sighting',

--- a/src/pages/sighting/encounters/Encounters.jsx
+++ b/src/pages/sighting/encounters/Encounters.jsx
@@ -212,9 +212,9 @@ export default function Encounters({
 
         const actionButtonActions = [
           {
-            id: 'rerun-id',
-            labelId: 'RERUN_IDENTIFICATION',
-            onClick: Function.prototype,
+            id: 'view-individual',
+            labelId: 'VIEW_INDIVIDUAL',
+            href: `/individuals/${individualGuid}`,
           },
         ];
 

--- a/src/pages/sighting/identification/RerunIdentificationDialog.jsx
+++ b/src/pages/sighting/identification/RerunIdentificationDialog.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
+
+import useRunIdOnSighting from '../../../models/sighting/useRunIdOnSighting';
+import CustomAlert from '../../../components/Alert';
+import Button from '../../../components/Button';
+import StandardDialog from '../../../components/StandardDialog';
+import Text from '../../../components/Text';
+import CustomMatchingSetForm from './CustomMatchingSetForm';
+
+export default function RerunIdentificationDialog({
+  sightingGuid,
+  open,
+  onClose,
+}) {
+  const [idConfig, setIdConfig] = useState(null);
+
+  const {
+    mutate: runIdentification,
+    loading,
+    error,
+    clearError,
+  } = useRunIdOnSighting();
+
+  return (
+    <StandardDialog
+      PaperProps={{ style: { width: 800 } }}
+      maxWidth="xl"
+      open={open}
+      onClose={() => {
+        clearError();
+        onClose();
+      }}
+      titleId="RERUN_IDENTIFICATION"
+    >
+      <DialogContent style={{ minWidth: 200 }}>
+        <CustomMatchingSetForm
+          idConfig={idConfig}
+          setIdConfig={setIdConfig}
+        />
+        {error && (
+          <CustomAlert severity="error" titleId="SERVER_ERROR">
+            <Text variant="body2">{error}</Text>
+          </CustomAlert>
+        )}
+      </DialogContent>
+      <DialogActions style={{ padding: '0px 24px 24px 24px' }}>
+        <Button display="basic" onClick={onClose} id="CANCEL" />
+        <Button
+          loading={loading}
+          display="primary"
+          onClick={async () => {
+            const response = await runIdentification({
+              sightingGuid,
+              data: [idConfig],
+            });
+            if (response.status === 200) onClose();
+          }}
+          id="RERUN_IDENTIFICATION"
+        />
+      </DialogActions>
+    </StandardDialog>
+  );
+}


### PR DESCRIPTION
This PR adds the button to re-run identification on a sighting, but I am not seeing the any changes to the pipeline_status property after a successful POST to `/api/v1/sightings/8be7d16b-eb8f-4b6f-bec4-54d3daca0394/rerun_id`. Since Howard is out I wonder if someone else can look into it, maybe @naknomum or @bluemellophone?