### PR TITLE
Cleanup placeholders - sighting history and site setup

### DIFF
--- a/src/pages/setup/SiteSetup.jsx
+++ b/src/pages/setup/SiteSetup.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
+
+import { useTheme } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
+
 import MainColumn from '../../components/MainColumn';
 import Text from '../../components/Text';
-import newSiteImage from '../../assets/newsite.png';
+import BaoWaving from '../../components/svg/BaoWaving';
 import SiteSetupForm from './SiteSetupForm';
 import useDocumentTitle from '../../hooks/useDocumentTitle';
 
@@ -11,14 +14,16 @@ export default function SiteSetup() {
     appendSiteName: false,
     translateMessage: false,
   });
+  const theme = useTheme();
+  const themeColor = theme.palette.primary.main;
+
   return (
     <MainColumn>
       <Grid container direction="column" alignItems="center">
         <Grid item>
-          <img
-            style={{ margin: 50 }}
-            alt="new site graphic"
-            src={newSiteImage}
+          <BaoWaving
+            style={{ width: 280, margin: '32px 24px 24px' }}
+            themeColor={themeColor}
           />
         </Grid>
         <Grid item>

--- a/src/pages/sighting/SightingCore.jsx
+++ b/src/pages/sighting/SightingCore.jsx
@@ -20,7 +20,7 @@ import SightingEntityHeader from './SightingEntityHeader';
 import Annotations from './Annotations';
 import Photographs from './Photographs';
 import OverviewContent from './OverviewContent';
-import SightingHistoryDialog from './SightingHistoryDialog';
+// import SightingHistoryDialog from './SightingHistoryDialog';
 import CommitBanner from './CommitBanner';
 import Encounters from './encounters/Encounters';
 
@@ -74,7 +74,7 @@ export default function SightingCore({
 
   useDocumentTitle(`Sighting ${id}`, { translateMessage: false });
 
-  const [historyOpen, setHistoryOpen] = useState(false);
+  // const [historyOpen, setHistoryOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const activeTab = window.location.hash || '#overview';
 
@@ -97,10 +97,10 @@ export default function SightingCore({
 
   return (
     <MainColumn fullWidth>
-      <SightingHistoryDialog
+      {/* <SightingHistoryDialog
         open={historyOpen}
         onClose={() => setHistoryOpen(false)}
-      />
+      /> */}
       <ConfirmDelete
         open={deleteDialogOpen}
         onClose={() => setDeleteDialogOpen(false)}
@@ -138,7 +138,7 @@ export default function SightingCore({
         loading={loading}
         pending={pending}
         guid={id}
-        setHistoryOpen={setHistoryOpen}
+        // setHistoryOpen={setHistoryOpen}
         setDeleteDialogOpen={setDeleteDialogOpen}
       />
       <CommitBanner

--- a/src/pages/sighting/SightingEntityHeader.jsx
+++ b/src/pages/sighting/SightingEntityHeader.jsx
@@ -41,7 +41,7 @@ export default function SightingEntityHeader({
   loading,
   pending,
   guid,
-  setHistoryOpen,
+  // setHistoryOpen,
   setDeleteDialogOpen,
 }) {
   const intl = useIntl();
@@ -119,11 +119,11 @@ export default function SightingEntityHeader({
             <MoreMenu
               menuId="sighting-actions"
               items={[
-                {
-                  id: 'view-history',
-                  onClick: () => setHistoryOpen(true),
-                  label: 'View history',
-                },
+                // {
+                //   id: 'view-history',
+                //   onClick: () => setHistoryOpen(true),
+                //   label: 'View history',
+                // },
                 {
                   id: 'mark-reviewed',
                   onClick: () => setReviewDialogOpen(true),


### PR DESCRIPTION
- Comments out the sighting history dialog to hide it from users while it is still using mock data.
- Replaces the dolphin image on the site setup page with Bao.

| before | after |
| ---       | ---    |
| <img width="604" alt="before" src="https://user-images.githubusercontent.com/50299119/170741058-6a2514bf-8488-425f-8e45-3a5a1eafb164.png"> | <img width="536" alt="after" src="https://user-images.githubusercontent.com/50299119/170741082-b923aa00-e737-48c4-88e8-144f5aadb81d.png">

