### PR TITLE
Basic image processing handling

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1083,5 +1083,6 @@
   "PASSWORD_RESET_SUCCESSFUL": "Password was successfully reset!",
   "PASSWORD_RESET_ERROR": "Password reset error",
   "PASSWORD_RESET_SUCCESS": "Password reset success",
-  "RETURN_TO_LOGIN_PAGE": "Return to login page"
+  "RETURN_TO_LOGIN_PAGE": "Return to login page",
+  "PENDING": "pending"
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -130,6 +130,8 @@
   "IN_PROGRESS": "In progress.",
   "NEW_INDIVIDUAL_CREATED_DESCRIPTION": "New individual created.",
   "PENDING_BULK_IMPORT_MESSAGE": "You reported {sightingCount} sightings on {date}. You must finish processing this bulk import before starting another.",
+  "PENDING_IMAGE_PROCESSING": "Image processing in progress",
+  "PENDING_IMAGE_PROCESSING_MESSAGE": "Until this step is complete, images cannot be viewed and some functionality is unavailable.",
   "HISTORY": "History",
   "DETECTION_SKIPPED_MESSAGE": "Detection skipped, either there are no images or no detection model was specified.",
   "CURATION_SKIPPED_MESSAGE": "Curation skipped - no images to curate.",

--- a/src/models/assetGroup/useAssetGroup.js
+++ b/src/models/assetGroup/useAssetGroup.js
@@ -1,9 +1,13 @@
 import { getAssetGroupQueryKey } from '../../constants/queryKeys';
 import useFetch from '../../hooks/useFetch';
 
-export default function useAssetGroup(assetGroupId) {
+export default function useAssetGroup(
+  assetGroupId,
+  { queryOptions } = {},
+) {
   return useFetch({
     queryKey: getAssetGroupQueryKey(assetGroupId),
     url: `/asset_groups/${assetGroupId}`,
+    queryOptions,
   });
 }

--- a/src/pages/assetGroup/AGSTable.jsx
+++ b/src/pages/assetGroup/AGSTable.jsx
@@ -8,13 +8,17 @@ import { cellRendererTypes } from '../../components/dataDisplays/cellRenderers';
 
 export default function AGSTable({ assetGroupSightings }) {
   const intl = useIntl();
+  const pendingMessage = intl.formatMessage({ id: 'PENDING' });
 
   const transformedData = assetGroupSightings.map(ags => ({
     ...ags,
     time: ags?.config?.sighting?.time,
     timeSpecificity: ags?.config?.sighting?.timeSpecificity,
     locationId: ags?.config?.sighting?.locationId,
-    assetCount: get(ags, ['assets', 'length'], 0),
+    assetCount:
+      ags?.stage === 'preparation'
+        ? pendingMessage
+        : get(ags, ['assets', 'length'], 0),
   }));
 
   const columns = [

--- a/src/pages/assetGroup/AssetGroup.jsx
+++ b/src/pages/assetGroup/AssetGroup.jsx
@@ -25,9 +25,8 @@ import AGSTable from './AGSTable';
 const POLLING_INTERVAL = 5000; // 5 seconds
 
 function deriveRefetchInterval(resultData, query) {
-  const { complete, status } = {
-    ...resultData?.data?.progress_preparation,
-  };
+  const { complete, status } =
+    resultData?.data?.progress_preparation || {};
 
   const error = query.state?.error && { ...query.state.error };
 

--- a/src/pages/sighting/SightingCore.jsx
+++ b/src/pages/sighting/SightingCore.jsx
@@ -12,6 +12,7 @@ import MainColumn from '../../components/MainColumn';
 import LoadingScreen from '../../components/LoadingScreen';
 import SadScreen from '../../components/SadScreen';
 import ConfirmDelete from '../../components/ConfirmDelete';
+import CustomAlert from '../../components/Alert';
 import useDocumentTitle from '../../hooks/useDocumentTitle';
 import useDeleteSighting from '../../models/sighting/useDeleteSighting';
 import useDeleteAssetGroupSighting from '../../models/assetGroupSighting/useDeleteAssetGroupSighting';
@@ -95,6 +96,11 @@ export default function SightingCore({
 
   const assets = get(data, 'assets', []);
 
+  const isPreparationInProgress = get(
+    data,
+    'pipeline_status.preparation.inProgress',
+  );
+
   return (
     <MainColumn fullWidth>
       {/* <SightingHistoryDialog
@@ -141,11 +147,20 @@ export default function SightingCore({
         // setHistoryOpen={setHistoryOpen}
         setDeleteDialogOpen={setDeleteDialogOpen}
       />
-      <CommitBanner
-        sightingId={id}
-        pending={pending}
-        sightingData={data}
-      />
+      {isPreparationInProgress ? (
+        <CustomAlert
+          titleId="PENDING_IMAGE_PROCESSING"
+          descriptionId="PENDING_IMAGE_PROCESSING_MESSAGE"
+          severity="info"
+          style={{ marginBottom: 24 }}
+        />
+      ) : (
+        <CommitBanner
+          sightingId={id}
+          pending={pending}
+          sightingData={data}
+        />
+      )}
       {activeTab === '#overview' && (
         <OverviewContent
           metadata={metadata}

--- a/src/pages/sighting/SightingCore.jsx
+++ b/src/pages/sighting/SightingCore.jsx
@@ -25,6 +25,13 @@ import OverviewContent from './OverviewContent';
 import CommitBanner from './CommitBanner';
 import Encounters from './encounters/Encounters';
 
+const sightingTabs = {
+  '#overview': '#overview',
+  '#annotations': '#annotations',
+  '#photographs': '#photographs',
+  '#individuals': '#individuals',
+};
+
 export default function SightingCore({
   data,
   loading,
@@ -77,7 +84,15 @@ export default function SightingCore({
 
   // const [historyOpen, setHistoryOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const activeTab = window.location.hash || '#overview';
+
+  const isPreparationInProgress = get(
+    data,
+    'pipeline_status.preparation.inProgress',
+  );
+
+  const activeTab = isPreparationInProgress
+    ? sightingTabs['#overview']
+    : sightingTabs[window.location.hash] || sightingTabs['#overview'];
 
   if (error) {
     return (
@@ -95,11 +110,6 @@ export default function SightingCore({
   if (loading) return <LoadingScreen />;
 
   const assets = get(data, 'assets', []);
-
-  const isPreparationInProgress = get(
-    data,
-    'pipeline_status.preparation.inProgress',
-  );
 
   return (
     <MainColumn fullWidth>
@@ -143,6 +153,7 @@ export default function SightingCore({
         data={data}
         loading={loading}
         pending={pending}
+        preparing={isPreparationInProgress}
         guid={id}
         // setHistoryOpen={setHistoryOpen}
         setDeleteDialogOpen={setDeleteDialogOpen}

--- a/src/pages/sighting/SightingEntityHeader.jsx
+++ b/src/pages/sighting/SightingEntityHeader.jsx
@@ -4,6 +4,7 @@ import { get, map } from 'lodash-es';
 
 import Chip from '@material-ui/core/Chip';
 import DoneIcon from '@material-ui/icons/Done';
+import Skeleton from '@material-ui/lab/Skeleton';
 
 import ReviewSightingDialog from '../../components/dialogs/ReviewSightingDialog';
 import Link from '../../components/Link';
@@ -41,6 +42,7 @@ export default function SightingEntityHeader({
   data,
   loading,
   pending,
+  preparing,
   guid,
   // setHistoryOpen,
   setDeleteDialogOpen,
@@ -100,25 +102,33 @@ export default function SightingEntityHeader({
       />
       <EntityHeader
         renderAvatar={
-          <FeaturedPhoto
-            data={pending ? null : dataForFeaturedPhoto}
-            loading={loading}
-            defaultPhotoSrc={defaultSightingSrc}
-            sightingId={data?.guid}
-          />
+          preparing ? (
+            <Skeleton height={150} width={150} variant="rect" />
+          ) : (
+            <FeaturedPhoto
+              data={pending ? null : dataForFeaturedPhoto}
+              loading={loading}
+              defaultPhotoSrc={defaultSightingSrc}
+              sightingId={data?.guid}
+            />
+          )
         }
         name={intl.formatMessage(
           { id: 'ENTITY_HEADER_SIGHTING_DATE' },
           { date: sightingDisplayDate },
         )}
         renderTabs={
-          <Tabs
-            value={activeTab.replace('#', '')}
-            onChange={(_, newValue) => {
-              window.location.hash = newValue;
-            }}
-            items={tabItems}
-          />
+          preparing ? (
+            <div />
+          ) : (
+            <Tabs
+              value={activeTab.replace('#', '')}
+              onChange={(_, newValue) => {
+                window.location.hash = newValue;
+              }}
+              items={tabItems}
+            />
+          )
         }
         renderOptions={
           <div style={{ display: 'flex' }}>


### PR DESCRIPTION
- Bulk import page
  - Adds polling for the asset group while image processing is in progress so that the UI can change when processing is complete.
  - Adds a simple image processing alert indicating that image processing is in progress and that some functionality is not available.
  - Sets the asset counts in the table to "pending".
- Pending sighting page
  - Adds the same basic image processing alert.
  - Hides all of the tabs while image processing is in progress.
  - Uses a Material UI Skeleton instead of a featured photo while image processing is in progress.
- Changes how the `activeTab` is calculated so that it is only ever a valid value.

These changes span both DEX-1083 and DEX-967


<img width="980" alt="bulk-in-progress" src="https://user-images.githubusercontent.com/50299119/170800536-664449f0-dcb1-492f-9836-4b645c9299da.png">

-----

<img width="980" alt="sighting-in-progress" src="https://user-images.githubusercontent.com/50299119/170800571-25fd9435-590a-4cfe-98a1-f17a1cfcbc11.png">

*Please ignore the status card being incorrect on the sighting page. This will be fixed in #362*