### PR TITLE
Dex 477 right align filtered icons

### DIFF
--- a/src/components/dataDisplays/CollapsibleRow.jsx
+++ b/src/components/dataDisplays/CollapsibleRow.jsx
@@ -46,8 +46,6 @@ export default function CollapsibleRow({
             'options.cellRenderer',
             'default',
           );
-          console.log('deleteMe requestedCellRenderer is: ');
-          console.log(requestedCellRenderer);
           const cellRendererProps = get(
             c,
             'options.cellRendererProps',
@@ -59,10 +57,6 @@ export default function CollapsibleRow({
           );
           const RequestedCellRenderer =
             cellRenderers[requestedCellRenderer];
-          const deleteMeAlignment = getCellAlignment(i, c);
-          console.log('deleteMeAlignment is: ');
-          console.log(deleteMeAlignment);
-
           return (
             <TableCell
               key={c.name}

--- a/src/components/dataDisplays/CollapsibleRow.jsx
+++ b/src/components/dataDisplays/CollapsibleRow.jsx
@@ -46,6 +46,8 @@ export default function CollapsibleRow({
             'options.cellRenderer',
             'default',
           );
+          console.log('deleteMe requestedCellRenderer is: ');
+          console.log(requestedCellRenderer);
           const cellRendererProps = get(
             c,
             'options.cellRendererProps',
@@ -57,6 +59,9 @@ export default function CollapsibleRow({
           );
           const RequestedCellRenderer =
             cellRenderers[requestedCellRenderer];
+          const deleteMeAlignment = getCellAlignment(i, c);
+          console.log('deleteMeAlignment is: ');
+          console.log(deleteMeAlignment);
 
           return (
             <TableCell

--- a/src/pages/userManagement/UserEditTable.jsx
+++ b/src/pages/userManagement/UserEditTable.jsx
@@ -66,7 +66,9 @@ export default function UserEditTable() {
       options: {
         displayInFilter: false,
         customBodyRender: (_, user) => (
-          <div style={{ display: 'flex' }}>
+          <div
+            style={{ display: 'flex', justifyContent: 'flex-end' }}
+          >
             <ActionIcon
               variant="view"
               href={`/users/${get(user, 'guid')}`}


### PR DESCRIPTION
Fixes issue where the action icons would not be right-justified after filtering in the user edit table:
<img width="1552" alt="Screen Shot 2022-05-30 at 3 02 20 PM" src="https://user-images.githubusercontent.com/2775448/171063162-6063fbda-62f5-4257-b496-3347b054a29a.png">

