### PR TITLE
Use site settings instead of apiKeys.js

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Install dependencies
         run: npm install --legacy-peer-deps
 
-      - name: Copy template api keys file
-        run: cp src/constants/apiKeysTemplate.js src/constants/apiKeys.js
-
       - name: Compile build
         run: npm run build -- --env=houston=relative
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ package-lock.json
 .DS_Store
 .vscode/
 
-/src/constants/apiKeys.js
 #: created on build
 /src/constants/version.js
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We are also looking for help from designers and 3D modelers! Please send an emai
 
 ## Development 
 
-To successfully run the project, you will need to recreate one file that is gitignored for security reasons, `/src/constants/apiKeys.js`. Follow the instructions in the template located at `/src/constants/apiKeysTemplate.js`. After that, just run
+Just run
 
 ```js
 npm install 

--- a/src/components/fields/edit/mapUtils/LatLngMap.jsx
+++ b/src/components/fields/edit/mapUtils/LatLngMap.jsx
@@ -1,12 +1,18 @@
 import React, { useState } from 'react';
+import { get } from 'lodash-es';
 import GoogleMapReact from 'google-map-react';
-import { googleMapsApiKey } from '../../../../constants/apiKeys';
+import useSiteSettings from '../../../../models/site/useSiteSettings';
 
 let lastMarker = null;
 
 export default function LatLngMap({ onChange, rest }) {
   const [mapObject, setMapObject] = useState(null);
   const [mapsApi, setMapsApi] = useState(null);
+  const googleMapsApiKey = get(useSiteSettings(), [
+    'data',
+    'googleMapsApiKey',
+    'value',
+  ]);
 
   return (
     <div

--- a/src/components/fields/edit/mapUtils/LatLngMap.jsx
+++ b/src/components/fields/edit/mapUtils/LatLngMap.jsx
@@ -1,18 +1,13 @@
 import React, { useState } from 'react';
-import { get } from 'lodash-es';
 import GoogleMapReact from 'google-map-react';
-import useSiteSettings from '../../../../models/site/useSiteSettings';
+import useGoogleMapsApiKey from '../../../../hooks/useGoogleMapsApiKey';
 
 let lastMarker = null;
 
 export default function LatLngMap({ onChange, rest }) {
   const [mapObject, setMapObject] = useState(null);
   const [mapsApi, setMapsApi] = useState(null);
-  const googleMapsApiKey = get(useSiteSettings(), [
-    'data',
-    'googleMapsApiKey',
-    'value',
-  ]);
+  const googleMapsApiKey = useGoogleMapsApiKey();
 
   return (
     <div

--- a/src/components/fields/filter/mapUtils/AreaMap.jsx
+++ b/src/components/fields/filter/mapUtils/AreaMap.jsx
@@ -2,14 +2,10 @@ import React from 'react';
 import { get } from 'lodash-es';
 import GoogleMapReact from 'google-map-react';
 import { defaultAreaBounds } from '../../../../constants/defaults';
-import useSiteSettings from '../../../../models/site/useSiteSettings';
+import useGoogleMapsApiKey from '../../../../hooks/useGoogleMapsApiKey';
 
 export default function Map({ startBounds, onChange, rest }) {
-  const googleMapsApiKey = get(useSiteSettings(), [
-    'data',
-    'googleMapsApiKey',
-    'value',
-  ]);
+  const googleMapsApiKey = useGoogleMapsApiKey();
   return (
     <div
       style={{

--- a/src/components/fields/filter/mapUtils/AreaMap.jsx
+++ b/src/components/fields/filter/mapUtils/AreaMap.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import { get } from 'lodash-es';
 import GoogleMapReact from 'google-map-react';
-import { googleMapsApiKey } from '../../../../constants/apiKeys';
 import { defaultAreaBounds } from '../../../../constants/defaults';
+import useSiteSettings from '../../../../models/site/useSiteSettings';
 
 export default function Map({ startBounds, onChange, rest }) {
+  const googleMapsApiKey = get(useSiteSettings(), [
+    'data',
+    'googleMapsApiKey',
+    'value',
+  ]);
   return (
     <div
       style={{

--- a/src/components/filterFields/mapUtils/PointDistanceMap.jsx
+++ b/src/components/filterFields/mapUtils/PointDistanceMap.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { get } from 'lodash-es';
 import GoogleMapReact from 'google-map-react';
-import useSiteSettings from '../../../models/site/useSiteSettings';
+import useGoogleMapsApiKey from '../../../hooks/useGoogleMapsApiKey';
 
 let lastMarker = null;
 let lastCircle = null;
@@ -86,11 +86,7 @@ export default function PointDistanceMap({
     [mapReadyToRender],
   );
 
-  const googleMapsApiKey = get(useSiteSettings(), [
-    'data',
-    'googleMapsApiKey',
-    'value',
-  ]);
+  const googleMapsApiKey = useGoogleMapsApiKey();
 
   return (
     <div

--- a/src/components/filterFields/mapUtils/PointDistanceMap.jsx
+++ b/src/components/filterFields/mapUtils/PointDistanceMap.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { get } from 'lodash-es';
 import GoogleMapReact from 'google-map-react';
-import { googleMapsApiKey } from '../../../constants/apiKeys';
+import useSiteSettings from '../../../models/site/useSiteSettings';
 
 let lastMarker = null;
 let lastCircle = null;
@@ -85,6 +85,12 @@ export default function PointDistanceMap({
     },
     [mapReadyToRender],
   );
+
+  const googleMapsApiKey = get(useSiteSettings(), [
+    'data',
+    'googleMapsApiKey',
+    'value',
+  ]);
 
   return (
     <div

--- a/src/components/inputs/mapUtils/AreaMap.jsx
+++ b/src/components/inputs/mapUtils/AreaMap.jsx
@@ -2,14 +2,10 @@ import React from 'react';
 import { get } from 'lodash-es';
 import GoogleMapReact from 'google-map-react';
 import { defaultAreaBounds } from '../../../constants/defaults';
-import useSiteSettings from '../../../models/site/useSiteSettings';
+import useGoogleMapsApiKey from '../../../hooks/useGoogleMapsApiKey';
 
 export default function Map({ startBounds, onChange, rest }) {
-  const googleMapsApiKey = get(useSiteSettings(), [
-    'data',
-    'googleMapsApiKey',
-    'value',
-  ]);
+  const googleMapsApiKey = useGoogleMapsApiKey();
   return (
     <div
       style={{

--- a/src/components/inputs/mapUtils/AreaMap.jsx
+++ b/src/components/inputs/mapUtils/AreaMap.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import { get } from 'lodash-es';
 import GoogleMapReact from 'google-map-react';
-import { googleMapsApiKey } from '../../../constants/apiKeys';
 import { defaultAreaBounds } from '../../../constants/defaults';
+import useSiteSettings from '../../../models/site/useSiteSettings';
 
 export default function Map({ startBounds, onChange, rest }) {
+  const googleMapsApiKey = get(useSiteSettings(), [
+    'data',
+    'googleMapsApiKey',
+    'value',
+  ]);
   return (
     <div
       style={{

--- a/src/components/inputs/mapUtils/LatLngMap.jsx
+++ b/src/components/inputs/mapUtils/LatLngMap.jsx
@@ -1,12 +1,18 @@
 import React, { useState } from 'react';
 import GoogleMapReact from 'google-map-react';
-import { googleMapsApiKey } from '../../../constants/apiKeys';
+import { get } from 'lodash-es';
+import useSiteSettings from '../../../models/site/useSiteSettings';
 
 let lastMarker = null;
 
 export default function LatLngMap({ onChange, rest }) {
   const [mapObject, setMapObject] = useState(null);
   const [mapsApi, setMapsApi] = useState(null);
+  const googleMapsApiKey = get(useSiteSettings(), [
+    'data',
+    'googleMapsApiKey',
+    'value',
+  ]);
 
   return (
     <div

--- a/src/components/inputs/mapUtils/LatLngMap.jsx
+++ b/src/components/inputs/mapUtils/LatLngMap.jsx
@@ -1,18 +1,14 @@
 import React, { useState } from 'react';
 import GoogleMapReact from 'google-map-react';
-import { get } from 'lodash-es';
-import useSiteSettings from '../../../models/site/useSiteSettings';
+
+import useGoogleMapsApiKey from '../../../hooks/useGoogleMapsApiKey';
 
 let lastMarker = null;
 
 export default function LatLngMap({ onChange, rest }) {
   const [mapObject, setMapObject] = useState(null);
   const [mapsApi, setMapsApi] = useState(null);
-  const googleMapsApiKey = get(useSiteSettings(), [
-    'data',
-    'googleMapsApiKey',
-    'value',
-  ]);
+  const googleMapsApiKey = useGoogleMapsApiKey();
 
   return (
     <div

--- a/src/components/maps/MultiplePoints.jsx
+++ b/src/components/maps/MultiplePoints.jsx
@@ -3,7 +3,7 @@ import GoogleMapReact from 'google-map-react';
 import { get } from 'lodash-es';
 import RoomIcon from '@material-ui/icons/Room';
 
-import { googleMapsApiKey } from '../../constants/apiKeys';
+import useSiteSettings from '../../models/site/useSiteSettings';
 import Marker from './Marker';
 
 function createMapOptions() {
@@ -16,6 +16,11 @@ export default function MultiplePoints({ latLongLabelArr }) {
   const [currentMarkerToShow, setCurrentMarkerToShow] = useState(
     null,
   );
+  const googleMapsApiKey = get(useSiteSettings(), [
+    'data',
+    'googleMapsApiKey',
+    'value',
+  ]);
   return (
     <GoogleMapReact
       options={createMapOptions}
@@ -53,30 +58,28 @@ export default function MultiplePoints({ latLongLabelArr }) {
         const bounds = new maps.LatLngBounds(sw, ne);
         map.setCenter(bounds.getCenter());
         map.fitBounds(bounds, 10);
-        var opt = { minZoom: 0, maxZoom: 5 };
+        const opt = { minZoom: 0, maxZoom: 5 };
         map.setOptions(opt);
         map.setZoom(Math.max(map.getZoom() - 1, 0)); // add some buffer space to it
       }}
     >
-      {latLongLabelArr.map(entry => {
-        return (
-          <Marker
-            entry={entry}
-            currentMarkerToShow={currentMarkerToShow}
-            setCurrentMarkerToShow={setCurrentMarkerToShow}
-            key={get(entry, 'text', '')}
-            lat={get(entry, 'lat')}
-            lng={get(entry, 'long')}
-          >
-            <RoomIcon
-              style={{
-                position: 'absolute',
-                transform: 'translate(-50%,-50%)',
-              }}
-            />
-          </Marker>
-        );
-      })}
+      {latLongLabelArr.map(entry => (
+        <Marker
+          entry={entry}
+          currentMarkerToShow={currentMarkerToShow}
+          setCurrentMarkerToShow={setCurrentMarkerToShow}
+          key={get(entry, 'text', '')}
+          lat={get(entry, 'lat')}
+          lng={get(entry, 'long')}
+        >
+          <RoomIcon
+            style={{
+              position: 'absolute',
+              transform: 'translate(-50%,-50%)',
+            }}
+          />
+        </Marker>
+      ))}
     </GoogleMapReact>
   );
 }

--- a/src/components/maps/MultiplePoints.jsx
+++ b/src/components/maps/MultiplePoints.jsx
@@ -3,8 +3,8 @@ import GoogleMapReact from 'google-map-react';
 import { get } from 'lodash-es';
 import RoomIcon from '@material-ui/icons/Room';
 
-import useSiteSettings from '../../models/site/useSiteSettings';
 import Marker from './Marker';
+import useGoogleMapsApiKey from '../../hooks/useGoogleMapsApiKey';
 
 function createMapOptions() {
   return {
@@ -16,11 +16,7 @@ export default function MultiplePoints({ latLongLabelArr }) {
   const [currentMarkerToShow, setCurrentMarkerToShow] = useState(
     null,
   );
-  const googleMapsApiKey = get(useSiteSettings(), [
-    'data',
-    'googleMapsApiKey',
-    'value',
-  ]);
+  const googleMapsApiKey = useGoogleMapsApiKey();
   return (
     <GoogleMapReact
       options={createMapOptions}

--- a/src/components/maps/SinglePoint.jsx
+++ b/src/components/maps/SinglePoint.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import GoogleMapReact from 'google-map-react';
+import { get } from 'lodash-es';
 
-import { googleMapsApiKey } from '../../constants/apiKeys';
+import useSiteSettings from '../../models/site/useSiteSettings';
 
 function createMapOptions() {
   return {
@@ -10,6 +11,11 @@ function createMapOptions() {
 }
 
 export default function SinglePoint({ lat, lng }) {
+  const googleMapsApiKey = get(useSiteSettings(), [
+    'data',
+    'googleMapsApiKey',
+    'value',
+  ]);
   return (
     <GoogleMapReact
       options={createMapOptions}

--- a/src/components/maps/SinglePoint.jsx
+++ b/src/components/maps/SinglePoint.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import GoogleMapReact from 'google-map-react';
-import { get } from 'lodash-es';
 
-import useSiteSettings from '../../models/site/useSiteSettings';
+import useGoogleMapsApiKey from '../../hooks/useGoogleMapsApiKey';
 
 function createMapOptions() {
   return {
@@ -11,11 +10,7 @@ function createMapOptions() {
 }
 
 export default function SinglePoint({ lat, lng }) {
-  const googleMapsApiKey = get(useSiteSettings(), [
-    'data',
-    'googleMapsApiKey',
-    'value',
-  ]);
+  const googleMapsApiKey = useGoogleMapsApiKey();
   return (
     <GoogleMapReact
       options={createMapOptions}

--- a/src/constants/apiKeysTemplate.js
+++ b/src/constants/apiKeysTemplate.js
@@ -1,8 +1,0 @@
-/* To successfully run the app, you need to recreate a .gitignore'd file
-in this directory, apiKeys.js */
-
-export const googleMapsApiKey = '';
-
-export const sentryDsn = '';
-
-export const flatfileKey = '';

--- a/src/hooks/useGoogleMapsApiKey.js
+++ b/src/hooks/useGoogleMapsApiKey.js
@@ -1,0 +1,11 @@
+import { get } from 'lodash-es';
+
+import useSiteSettings from '../models/site/useSiteSettings';
+
+export default function useGoogleMapsApiKey() {
+  return get(useSiteSettings(), [
+    'data',
+    'googleMapsApiKey',
+    'value',
+  ]);
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,6 +2,7 @@ import 'react-hot-loader/root'; // This needs to be imported before React.
 import React from 'react';
 import { render } from 'react-dom';
 import * as Sentry from '@sentry/react';
+import axios from 'axios';
 import { get } from 'lodash-es';
 
 import 'normalize.css';
@@ -11,10 +12,11 @@ import './styles/globalStyles.css';
 import pjson from '../package.json';
 import App from './App';
 
-fetch(`${__houston_url__}/api/v1/site-settings/main/block`)
-  .then(response => response.json())
-  .then(result => {
-    const sentryDsn = get(result, [
+axios
+  .get(`${__houston_url__}/api/v1/site-settings/main/sentryDsn`)
+  .then(response => {
+    const sentryDsn = get(response, [
+      'data',
       'response',
       'configuration',
       'sentryDsn',

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,19 +8,29 @@ import 'normalize.css';
 import '../fonts/fonts.css';
 import './styles/globalStyles.css';
 
-import { sentryDsn } from './constants/apiKeys';
 import pjson from '../package.json';
 import App from './App';
 
-if (!__DEV__) {
-  Sentry.init({
-    dsn: sentryDsn,
-    release: `frontend@${get(pjson, 'release')}`,
+fetch(`${__houston_url__}/api/v1/site-settings/main/block`)
+  .then(response => response.json())
+  .then(result => {
+    const sentryDsn = get(result, [
+      'response',
+      'configuration',
+      'sentryDsn',
+      'value',
+    ]);
+    if (sentryDsn) {
+      Sentry.init({
+        dsn: sentryDsn,
+        release: `frontend@${get(pjson, 'release')}`,
+      });
+    }
+  })
+  .finally(() => {
+    const root = document.getElementById('root');
+
+    const load = () => render(<App />, root);
+
+    load();
   });
-}
-
-const root = document.getElementById('root');
-
-const load = () => render(<App />, root);
-
-load();

--- a/src/pages/bulkImport/BulkReportForm.jsx
+++ b/src/pages/bulkImport/BulkReportForm.jsx
@@ -14,7 +14,6 @@ import usePostAssetGroup from '../../models/assetGroup/usePostAssetGroup';
 import useSiteSettings from '../../models/site/useSiteSettings';
 import useSightingFieldSchemas from '../../models/sighting/useSightingFieldSchemas';
 import useEncounterFieldSchemas from '../../models/encounter/useEncounterFieldSchemas';
-import { flatfileKey } from '../../constants/apiKeys';
 import LoadingScreen from '../../components/LoadingScreen';
 import InputRow from '../../components/fields/edit/InputRow';
 import Button from '../../components/Button';
@@ -120,6 +119,7 @@ export default function BulkReportForm({ assetReferences }) {
 
   const safeAssetReferences = assetReferences || [];
   const filenames = safeAssetReferences.map(a => a?.path);
+  const flatfileKey = get(siteSettingsData, ['flatfileKey', 'value']);
 
   return (
     <>


### PR DESCRIPTION
- Remove apiKeysTemplate.js
- Change code to use site settings instead of apiKeys
- The settings are `googleMapsApiKey`, `flatfileKey` and `sentryDsn`
- Use `fetch` to get the sentry dsn and move react render App into the `finally` handler


See WildMeOrg/houston#665