### PR TITLE
Dex 929 follow up

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -639,7 +639,7 @@
   "TRY_AGAIN": "Resend email",
   "SUCCESSFULLY_LOGGED_OUT": "You have successfully logged out.",
   "LOGGED_OUT": "Logged out",
-  "ANNOTATION": "Annotation",
+  "CANDIDATE_RANK": "Candidate Rank",
   "FILENAME": "Filename",
   "MATCH": "Match",
   "CHANGE": "Change",
@@ -1091,5 +1091,6 @@
   "COLLABORATION_RESTORE_SUCCESS": "Successfully restored the collaboration",
   "COLLABORATION_RESTORE_ERROR": "Error restoring the collaboration",
   "COLLAB_RESTORE_ERROR_SUPPLEMENTAL": "Collaboration was not successfully restored.",
-  "PENDING": "pending"
+  "PENDING": "pending",
+  "CANDIDATE_ANNOTATIONS": "Candidate annotations"
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -640,6 +640,7 @@
   "SUCCESSFULLY_LOGGED_OUT": "You have successfully logged out.",
   "LOGGED_OUT": "Logged out",
   "CANDIDATE_RANK": "Candidate Rank",
+  "ANNOTATION": "Annotation",
   "FILENAME": "Filename",
   "MATCH": "Match",
   "CHANGE": "Change",

--- a/src/pages/match/MatchCandidatesTable.jsx
+++ b/src/pages/match/MatchCandidatesTable.jsx
@@ -7,9 +7,9 @@ import ActionIcon from '../../components/ActionIcon';
 const columns = [
   {
     name: 'index',
-    labelId: 'ANNOTATION',
+    labelId: 'CANDIDATE_RANK',
     options: {
-      customBodyRender: i => `C${i + 1}`,
+      customBodyRender: i => `${i + 1}`,
     },
   },
   {
@@ -36,6 +36,7 @@ const columns = [
   {
     name: 'sighting_guid',
     labelId: 'VIEW_SIGHTING',
+    sortable: false,
     options: {
       customBodyRender: guid => (
         <ActionIcon
@@ -57,9 +58,8 @@ export default function MatchCandidatesTable({
   return (
     <DataDisplay
       idKey="guid"
-      title="Match candidates"
-      data={matchCandidates}
-      // variant="secondary"
+      titleId="CANDIDATE_ANNOTATIONS"
+      data={matchCandidates} // variant="secondary"
       columns={columns}
       noResultsTextId="NO_MATCH_CANDIDATES"
       hideDownloadCsv

--- a/src/pages/match/QueryAnnotationsTable.jsx
+++ b/src/pages/match/QueryAnnotationsTable.jsx
@@ -6,7 +6,7 @@ import { cellRendererTypes } from '../../components/dataDisplays/cellRenderers';
 const columns = [
   {
     name: 'index',
-    labelId: 'CANDIDATE_RANK',
+    labelId: 'ANNOTATION',
     options: {
       customBodyRender: i => `${i + 1}`,
     },

--- a/src/pages/match/QueryAnnotationsTable.jsx
+++ b/src/pages/match/QueryAnnotationsTable.jsx
@@ -6,9 +6,9 @@ import { cellRendererTypes } from '../../components/dataDisplays/cellRenderers';
 const columns = [
   {
     name: 'index',
-    labelId: 'ANNOTATION',
+    labelId: 'CANDIDATE_RANK',
     options: {
-      customBodyRender: i => `Q${i + 1}`,
+      customBodyRender: i => `${i + 1}`,
     },
   },
   {


### PR DESCRIPTION
Ticket recommendations:

- Rename “Annotation” to “Candidate Rank”
- Rename “Match candidates” to “Candidate Annotations”
- Remove “C” from match candidate listings
- View Sighting column no longer sortable

Note that "Candidate Annotations" instead of Candidate annotations" seems to go against a style choice that Ben has  made app-wide, so I kept as, "Candidate annotations".

Also changed the Q1 to just 1 on the query table after a chat with Tanya about it.

<img width="1552" alt="Screen Shot 2022-06-02 at 4 11 35 PM" src="https://user-images.githubusercontent.com/2775448/171752957-e0ae60bb-5606-4977-8f89-d59dd97d7aa4.png">


