### PR TITLE
Dex 1091 quieter twitterbot

### DIFF
--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -30,7 +30,7 @@ export default function useFetch({
 }) {
   const [displayedError, setDisplayedError] = useState(null);
   const [displayedLoading, setDisplayedLoading] = useState(
-    !queryOptions.disabled,
+    !queryOptions.disabled, // should this use enabled instead of disabled? I couldn't find anything in the react-query documentation about disabled.
   );
   const [statusCode, setStatusCode] = useState(null);
 

--- a/src/models/site/useGetTwitterbotTestResults.js
+++ b/src/models/site/useGetTwitterbotTestResults.js
@@ -1,13 +1,13 @@
 import queryKeys from '../../constants/queryKeys';
 import useFetch from '../../hooks/useFetch';
 
-export default function useGetTwitterbotTestResults(disabled) {
+export default function useGetTwitterbotTestResults(enabled) {
   return useFetch({
     queryKey: queryKeys.twitterBotTestResults,
     url: '/site-settings/test/intelligent_agent_twitterbot',
     queryOptions: {
       retry: 1,
-      disabled,
+      enabled,
     },
   });
 }

--- a/src/models/site/useGetTwitterbotTestResults.js
+++ b/src/models/site/useGetTwitterbotTestResults.js
@@ -6,8 +6,8 @@ export default function useGetTwitterbotTestResults(enabled) {
     queryKey: queryKeys.twitterBotTestResults,
     url: '/site-settings/test/intelligent_agent_twitterbot',
     queryOptions: {
-      retry: 1,
       enabled,
+      retry: 1,
     },
   });
 }

--- a/src/pages/generalSettings/GeneralSettings.jsx
+++ b/src/pages/generalSettings/GeneralSettings.jsx
@@ -74,13 +74,13 @@ export default function GeneralSettings() {
   ] = useState(false);
   console.log('deleteMe currentValues are: ');
   console.log(currentValues);
-  const isTwitterEnabled = get(
-    currentValues,
-    'intelligent_agent_twitterbot_enabled',
-  );
-  // const isTwitterEnabled = Boolean(
-  //   get(currentValues, 'intelligent_agent_twitterbot_enabled'),
+  // const isTwitterEnabled = get(
+  //   currentValues,
+  //   'intelligent_agent_twitterbot_enabled',
   // );
+  const isTwitterEnabled = Boolean(
+    get(currentValues, 'intelligent_agent_twitterbot_enabled'),
+  );
   console.log('deleteMe isTwitterEnabled is: ' + isTwitterEnabled);
 
   const {

--- a/src/pages/generalSettings/GeneralSettings.jsx
+++ b/src/pages/generalSettings/GeneralSettings.jsx
@@ -72,10 +72,11 @@ export default function GeneralSettings() {
     intelligentAgentFieldsValid,
     setIntelligentAgentFieldsValid,
   ] = useState(false);
-  const isTwitterDisabled = !get(
+  const isTwitterEnabled = get(
     currentValues,
     'intelligent_agent_twitterbot_enabled',
   );
+  console.log('deleteMe isTwitterEnabled is: ' + isTwitterEnabled);
 
   const {
     mutate: putSiteSettings,
@@ -96,7 +97,7 @@ export default function GeneralSettings() {
     data: twitterTestResults,
     statusCode: twitterStatusCode,
     error: twitterTestError,
-  } = useGetTwitterbotTestResults(isTwitterDisabled);
+  } = useGetTwitterbotTestResults(isTwitterEnabled);
 
   useDocumentTitle('GENERAL_SETTINGS');
 
@@ -271,7 +272,7 @@ export default function GeneralSettings() {
               {error}
             </CustomAlert>
           )}
-          {twitterTestError && !isTwitterDisabled && (
+          {twitterTestError && isTwitterEnabled && (
             <CustomAlert
               severity="warning"
               titleId="TWITTERBOT_NOT_CONFIGURED"

--- a/src/pages/generalSettings/GeneralSettings.jsx
+++ b/src/pages/generalSettings/GeneralSettings.jsx
@@ -72,16 +72,9 @@ export default function GeneralSettings() {
     intelligentAgentFieldsValid,
     setIntelligentAgentFieldsValid,
   ] = useState(false);
-  console.log('deleteMe currentValues are: ');
-  console.log(currentValues);
-  // const isTwitterEnabled = get(
-  //   currentValues,
-  //   'intelligent_agent_twitterbot_enabled',
-  // );
   const isTwitterEnabled = Boolean(
     get(currentValues, 'intelligent_agent_twitterbot_enabled'),
   );
-  console.log('deleteMe isTwitterEnabled is: ' + isTwitterEnabled);
 
   const {
     mutate: putSiteSettings,

--- a/src/pages/generalSettings/GeneralSettings.jsx
+++ b/src/pages/generalSettings/GeneralSettings.jsx
@@ -72,9 +72,8 @@ export default function GeneralSettings() {
     intelligentAgentFieldsValid,
     setIntelligentAgentFieldsValid,
   ] = useState(false);
-  const isTwitterEnabled = get(
-    currentValues,
-    'intelligent_agent_twitterbot_enabled',
+  const isTwitterEnabled = Boolean(
+    get(currentValues, 'intelligent_agent_twitterbot_enabled'),
   );
   console.log('deleteMe isTwitterEnabled is: ' + isTwitterEnabled);
 

--- a/src/pages/generalSettings/GeneralSettings.jsx
+++ b/src/pages/generalSettings/GeneralSettings.jsx
@@ -72,9 +72,15 @@ export default function GeneralSettings() {
     intelligentAgentFieldsValid,
     setIntelligentAgentFieldsValid,
   ] = useState(false);
-  const isTwitterEnabled = Boolean(
-    get(currentValues, 'intelligent_agent_twitterbot_enabled'),
+  console.log('deleteMe currentValues are: ');
+  console.log(currentValues);
+  const isTwitterEnabled = get(
+    currentValues,
+    'intelligent_agent_twitterbot_enabled',
   );
+  // const isTwitterEnabled = Boolean(
+  //   get(currentValues, 'intelligent_agent_twitterbot_enabled'),
+  // );
   console.log('deleteMe isTwitterEnabled is: ' + isTwitterEnabled);
 
   const {


### PR DESCRIPTION
This PR fixes the issue where useGetTwitterbotTestResults was being called despite having disabled passed to it as a queryOption.

I tried a number of things such as using enabled instead of disabled as the query option. These did not solve the issue (at least, they were not sufficient to solve the issue). However, I ended up using fewer double negatives in the codebase, so I decided to keep using enabled.

What I believe was the issue was gleaned from [this page](https://github.com/TanStack/query/issues/1196):

> Maybe you were setting enabled to a falsy value rather than really setting it to false ? This is a breaking change in v3 (stated here: https://react-query-beta.tanstack.com/guides/migrating-to-react-query-3#queryoptionsenabled). Falsy values will no longer work, it needs to really be the boolean value false.

So, despite `get(currentValues, 'intelligent_agent_twitterbot_enabled')` seeming to fetch a boolean value:
<img width="1552" alt="Screen Shot 2022-06-08 at 6 49 47 PM" src="https://user-images.githubusercontent.com/2775448/172746997-ff367711-2dc6-4040-83c9-d182a8f65f92.png">

, the issue disappeared as soon as I typecast to a Boolean explicitly with:

```
const isTwitterEnabled = Boolean(
    get(currentValues, 'intelligent_agent_twitterbot_enabled'),
  );
```
I do not understand why this seems to have been necessary.

I also noticed that `queryOptions.disabled` is being used to handle some `displayedLoading` logic in useFetch. I could not find any documentation about disabled as a queryOption; could this be a bug? If not, I'll remove the comment before merging.


To QA:
Open the network tab while loading /admin/settings. You should no longer see calls to intelligent_agent_twitterbot like this:

<img width="1552" alt="Screen Shot 2022-06-08 at 6 52 02 PM" src="https://user-images.githubusercontent.com/2775448/172747242-91fdde0c-152f-4d2f-b689-4069172e4145.png">


If you still see it, make sure that you have cleared out the network tab's calls before reloading the page.