### PR TITLE
dex 1083 - improved preparation state feedback for bulk import 

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -132,6 +132,8 @@
   "PENDING_BULK_IMPORT_MESSAGE": "You reported {sightingCount} sightings on {date}. You must finish processing this bulk import before starting another.",
   "PENDING_IMAGE_PROCESSING": "Image processing in progress",
   "PENDING_IMAGE_PROCESSING_MESSAGE": "Until this step is complete, images cannot be viewed and some functionality is unavailable.",
+  "IMAGE_PROCESSING_ERROR": "Image processing error",
+  "IMAGE_PROCESSING_ERROR_MESSAGE": "An unknown error has occurred; delete and rerun this import. If this problem occurs again, report this error on the Community Forums.",
   "HISTORY": "History",
   "IMAGE_PROCESSING_SKIPPED_MESSAGE": "Image processing skipped because no images were submitted.",
   "DETECTION_SKIPPED_MESSAGE": "Detection skipped, either there are no images or no detection model was specified.",

--- a/src/pages/assetGroup/AssetGroup.jsx
+++ b/src/pages/assetGroup/AssetGroup.jsx
@@ -4,6 +4,8 @@ import { useIntl } from 'react-intl';
 import { get } from 'lodash-es';
 import { useQueryClient } from 'react-query';
 
+import LinearProgress from '@material-ui/core/LinearProgress';
+
 import errorTypes from '../../constants/errorTypes';
 import useDeleteAssetGroup from '../../models/assetGroup/useDeleteAssetGroup';
 import useAssetGroup from '../../models/assetGroup/useAssetGroup';
@@ -152,11 +154,23 @@ export default function AssetGroup() {
         />
       )}
       {showPreparationInProgressAlert && (
-        <CustomAlert
-          titleId="PENDING_IMAGE_PROCESSING"
-          descriptionId="PENDING_IMAGE_PROCESSING_MESSAGE"
-          severity="info"
-        />
+        <>
+          <LinearProgress
+            style={{
+              borderTopLeftRadius: '4px',
+              borderTopRightRadius: '4px',
+            }}
+          />
+          <CustomAlert
+            titleId="PENDING_IMAGE_PROCESSING"
+            descriptionId="PENDING_IMAGE_PROCESSING_MESSAGE"
+            severity="info"
+            style={{
+              borderTopLeftRadius: '0px',
+              borderTopRightRadius: '0px',
+            }}
+          />
+        </>
       )}
       <AGSTable
         assetGroupSightings={get(data, 'asset_group_sightings', [])}

--- a/src/pages/assetGroup/AssetGroup.jsx
+++ b/src/pages/assetGroup/AssetGroup.jsx
@@ -84,11 +84,15 @@ export default function AssetGroup() {
     intl.formatMessage({ id: 'UNNAMED_USER' });
   const creatorUrl = `/users/${sightingCreator?.guid}`;
 
-  const { complete: isPreparationProgressComplete } = get(
-    data,
-    'progress_preparation',
-    {},
-  );
+  const {
+    complete: isPreparationProgressComplete,
+    failed: isPreparationProgressFailed,
+    cancelled: isPreparationProgressCancelled,
+  } = get(data, 'progress_preparation', {});
+  const showPreparationErrorAlert =
+    isPreparationProgressFailed || isPreparationProgressCancelled;
+  const showPreparationInProgressAlert =
+    !showPreparationErrorAlert && !isPreparationProgressComplete;
 
   return (
     <MainColumn fullWidth>
@@ -140,7 +144,14 @@ export default function AssetGroup() {
           </Text>
         )}
       </EntityHeader>
-      {!isPreparationProgressComplete && (
+      {showPreparationErrorAlert && (
+        <CustomAlert
+          titleId="IMAGE_PROCESSING_ERROR"
+          descriptionId="IMAGE_PROCESSING_ERROR_MESSAGE"
+          severity="error"
+        />
+      )}
+      {showPreparationInProgressAlert && (
         <CustomAlert
           titleId="PENDING_IMAGE_PROCESSING"
           descriptionId="PENDING_IMAGE_PROCESSING_MESSAGE"


### PR DESCRIPTION
- Adds an error alert message.
- Adds an indeterminate progress bar to the in progress alert so that the page gives a slightly better impression that it is doing something.
  - eventually there will be metrics included in the alert and the progress bar will probably move into the alert too. This is a quick, intermediary change that hopefully improves the user experience slightly.

<img width="939" alt="error-message" src="https://user-images.githubusercontent.com/50299119/172969502-ab64ab35-13b5-45c5-9241-2c1ec22b58f1.png">

<img width="939" alt="progress-bar" src="https://user-images.githubusercontent.com/50299119/172969518-69a1e67e-9fe1-4a17-89e4-f71eca57b8d6.png">

## QA notes
- A large bulk import will show the in progress state naturally. You can force that state by stopping all of your celery containers.
- To force the error state:
  - stop your celery containers
  - add something that will error to the first line of the set function
https://github.com/WildMeOrg/houston/blob/a3dba0dd4804c1439aae90bc1ca08cc3896e5eac/app/modules/progress/models.py#L419
  - start your celery containers