### PR TITLE
Dex 1119 notification placeholder improvement

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1100,5 +1100,7 @@
   "PENDING": "pending",
   "CANDIDATE_ANNOTATIONS": "Candidate annotations",
   "SIGHTING_DELETE_VULNERABLE_INDIVIDUAL_MESSAGE": "Deleting this sighting would result in assigned individuals being deleted. Are you sure you want to continue?",
-  "REQUEST_REQUIRES_ADDITIONAL_CONFIRMATION": "Request requires additional confirmation"
+  "REQUEST_REQUIRES_ADDITIONAL_CONFIRMATION": "Request requires additional confirmation",
+  "COLLABORATION_DENIED_TITLE": "Collaboration denied",
+  "COLLABORATION_DENIED_BRIEF": "{userName} denied your collaboration request"
 }

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -106,6 +106,10 @@ export default function NotificationsPane({
               const timeSince = calculatePrettyTimeElapsedSince(
                 createdDate,
               );
+              const avatarName =
+                eval(notification?.notificationAvatar) || user1Name;
+              console.log('deleteMe avatarName is: ');
+              console.log(avatarName);
               return (
                 <React.Fragment key={notification.guid}>
                   <Grid
@@ -118,7 +122,7 @@ export default function NotificationsPane({
                     }}
                   >
                     <div style={{ display: 'flex' }}>
-                      <Avatar>{user1Name[0].toUpperCase()}</Avatar>
+                      <Avatar>{avatarName[0].toUpperCase()}</Avatar>
                       <NotificationPaneDisplayText
                         currentNotificationSchema={
                           currentNotificationSchema
@@ -190,7 +194,9 @@ export default function NotificationsPane({
                     }}
                   >
                     <Text
-                      style={{ color: theme.palette.text.secondary }}
+                      style={{
+                        color: theme.palette.text.secondary,
+                      }}
                     >
                       {intl.formatMessage(
                         { id: 'TIME_SINCE' },

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -107,7 +107,9 @@ export default function NotificationsPane({
                 createdDate,
               );
               const avatarName =
-                `${notification?.notificationAvatar}` || user1Name;
+                getNotificationProps[
+                  (notification?.notificationAvatar)
+                ] || user1Name;
               console.log('deleteMe avatarName is: ');
               console.log(avatarName);
               return (

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -105,10 +105,6 @@ export default function NotificationsPane({
                 createdDate,
               );
 
-              const avatarName =
-                getNotificationProps(notification)[
-                  (currentNotificationSchema?.notificationAvatar)
-                ] || 'Unnamed User';
               return (
                 <React.Fragment key={notification.guid}>
                   <Grid
@@ -121,7 +117,7 @@ export default function NotificationsPane({
                     }}
                   >
                     <div style={{ display: 'flex' }}>
-                      <Avatar>{avatarName[0].toUpperCase()}</Avatar>
+                      <Avatar>{userName[0].toUpperCase()}</Avatar>
                       <NotificationPaneDisplayText
                         currentNotificationSchema={
                           currentNotificationSchema

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -106,10 +106,9 @@ export default function NotificationsPane({
               const timeSince = calculatePrettyTimeElapsedSince(
                 createdDate,
               );
-              const avatarName =
-                getNotificationProps(notification)[
-                  (notification?.notificationAvatar)
-                ] || user1Name;
+              const avatarName = getNotificationProps(notification)[
+                (notification?.notificationAvatar)
+              ]; // || user1Name;
               // const avatarName = eval(notification?.notificationAvatar) || user1Name;
               console.log('deleteMe avatarName is: ');
               console.log(avatarName);

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -30,6 +30,8 @@ export default function NotificationsPane({
   shouldOpen,
   setShouldOpen,
 }) {
+  console.log('deleteMe notifications in notification pane are:');
+  console.log(notifications);
   const intl = useIntl();
   const queryClient = useQueryClient();
   const theme = useTheme();

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -110,7 +110,7 @@ export default function NotificationsPane({
               const avatarName =
                 getNotificationProps(notification)[
                   (currentNotificationSchema?.notificationAvatar)
-                ] || user1Name;
+                ] || 'Unnamed User';
               return (
                 <React.Fragment key={notification.guid}>
                   <Grid

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -106,6 +106,16 @@ export default function NotificationsPane({
               const timeSince = calculatePrettyTimeElapsedSince(
                 createdDate,
               );
+              const deleteMeA = getNotificationProps(notification);
+              console.log('deleteMe deleteMeA is: ');
+              console.log(deleteMeA);
+              const deleteMeB = notification?.notificationAvatar;
+              console.log('deleteMe deleteMeB is: ');
+              console.log(deleteMeB);
+              const deleteMeC = deleteMeA[deleteMeB];
+              console.log('deleteMe deleteMeC is: ');
+              console.log(deleteMeC);
+
               const avatarName = getNotificationProps(notification)[
                 (notification?.notificationAvatar)
               ]; // || user1Name;

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -106,23 +106,11 @@ export default function NotificationsPane({
               const timeSince = calculatePrettyTimeElapsedSince(
                 createdDate,
               );
-              const deleteMeA = getNotificationProps(notification);
-              console.log('deleteMe deleteMeA is: ');
-              console.log(deleteMeA);
-              const deleteMeB =
-                currentNotificationSchema?.notificationAvatar;
-              console.log('deleteMe deleteMeB is: ');
-              console.log(deleteMeB);
-              const deleteMeC = deleteMeA[deleteMeB];
-              console.log('deleteMe deleteMeC is: ');
-              console.log(deleteMeC);
 
-              const avatarName = getNotificationProps(notification)[
-                (notification?.notificationAvatar)
-              ]; // || user1Name;
-              // const avatarName = eval(notification?.notificationAvatar) || user1Name;
-              console.log('deleteMe avatarName is: ');
-              console.log(avatarName);
+              const avatarName =
+                getNotificationProps(notification)[
+                  (currentNotificationSchema?.notificationAvatar)
+                ] || user1Name;
               return (
                 <React.Fragment key={notification.guid}>
                   <Grid

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -109,7 +109,8 @@ export default function NotificationsPane({
               const deleteMeA = getNotificationProps(notification);
               console.log('deleteMe deleteMeA is: ');
               console.log(deleteMeA);
-              const deleteMeB = notification?.notificationAvatar;
+              const deleteMeB =
+                currentNotificationSchema?.notificationAvatar;
               console.log('deleteMe deleteMeB is: ');
               console.log(deleteMeB);
               const deleteMeC = deleteMeA[deleteMeB];

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -107,9 +107,10 @@ export default function NotificationsPane({
                 createdDate,
               );
               const avatarName =
-                getNotificationProps[
+                getNotificationProps(notification)[
                   (notification?.notificationAvatar)
                 ] || user1Name;
+              // const avatarName = eval(notification?.notificationAvatar) || user1Name;
               console.log('deleteMe avatarName is: ');
               console.log(avatarName);
               return (

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -107,7 +107,7 @@ export default function NotificationsPane({
                 createdDate,
               );
               const avatarName =
-                eval(notification?.notificationAvatar) || user1Name;
+                `${notification?.notificationAvatar}` || user1Name;
               console.log('deleteMe avatarName is: ');
               console.log(avatarName);
               return (

--- a/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/NotificationsPane.jsx
@@ -30,8 +30,6 @@ export default function NotificationsPane({
   shouldOpen,
   setShouldOpen,
 }) {
-  console.log('deleteMe notifications in notification pane are:');
-  console.log(notifications);
   const intl = useIntl();
   const queryClient = useQueryClient();
   const theme = useTheme();

--- a/src/components/dialogs/notificationDialogUtils/NotificationCollaborationDeniedDialog.jsx
+++ b/src/components/dialogs/notificationDialogUtils/NotificationCollaborationDeniedDialog.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { get } from 'lodash-es';
+import { notificationSchema } from '../../../constants/notificationSchema';
+import NotificationDetailsDialog from '../NotificationDetailsDialog';
+
+export default function NotificationCollaborationDeniedDialog({
+  notification,
+  onClose,
+  open,
+}) {
+  const notificationType = notification?.message_type;
+  const currentNotificationSchema = get(
+    notificationSchema,
+    notificationType,
+  );
+  const availableButtons = [];
+  return (
+    <NotificationDetailsDialog
+      open={open}
+      onClose={onClose}
+      notification={notification}
+      titleId={get(currentNotificationSchema, 'titleId')}
+      moreDetailedDescription={get(
+        currentNotificationSchema,
+        'moreDetailedDescription',
+      )}
+      buttons={availableButtons}
+    />
+  );
+}

--- a/src/components/dialogs/notificationDialogUtils/index.js
+++ b/src/components/dialogs/notificationDialogUtils/index.js
@@ -2,6 +2,7 @@ import NotificationCollaborationManagerCreateDialog from './NotificationCollabor
 import NotificationCollaborationRequestDialog from './NotificationCollaborationRequestDialog';
 import NotificationCollaborationApprovedDialog from './NotificationCollaborationApprovedDialog';
 import NotificationCollaborationRevokedDialog from './NotificationCollaborationRevokedDialog';
+import NotificationCollaborationDeniedDialog from './NotificationCollaborationDeniedDialog';
 import NotificationCollaborationEditRequestDialog from './NotificationCollaborationEditRequestDialog';
 import NotificationCollaborationEditApprovedDialog from './NotificationCollaborationEditApprovedDialog';
 import NotificationCollaborationEditRevokeDialog from './NotificationCollaborationEditRevokeDialog';
@@ -16,6 +17,7 @@ export const notificationTypes = {
   [notificationTypeNames.collaboration_request]: NotificationCollaborationRequestDialog,
   [notificationTypeNames.collaboration_approved]: NotificationCollaborationApprovedDialog,
   [notificationTypeNames.collaboration_revoke]: NotificationCollaborationRevokedDialog,
+  [notificationTypeNames.collaboration_denied]: NotificationCollaborationDeniedDialog,
   [notificationTypeNames.collaboration_edit_request]: NotificationCollaborationEditRequestDialog,
   [notificationTypeNames.collaboration_edit_approved]: NotificationCollaborationEditApprovedDialog,
   [notificationTypeNames.collaboration_edit_revoke]: NotificationCollaborationEditRevokeDialog,

--- a/src/constants/notificationSchema.js
+++ b/src/constants/notificationSchema.js
@@ -22,7 +22,7 @@ notificationSchemaPlaceholder[
     'A_COLLABORATION_WAS_CREATED_ON_YOUR_BEHALF_MORE_DETAILED',
   showNotificationDialog: false,
   buttonPath: '/#collab-card',
-  notificationAvatar: '',
+  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_request

--- a/src/constants/notificationSchema.js
+++ b/src/constants/notificationSchema.js
@@ -94,6 +94,7 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'COLLABORATION_REVOKED_BY_MANAGER',
   showNotificationDialog: false,
   buttonPath: '/#collab-card',
+  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.individual_merge_request

--- a/src/constants/notificationSchema.js
+++ b/src/constants/notificationSchema.js
@@ -2,7 +2,8 @@ export const notificationTypeNames = {
   collaboration_manager_create: 'collaboration_manager_create',
   collaboration_request: 'collaboration_request',
   collaboration_approved: 'collaboration_approved',
-  collaboration_revoke: 'collaboration_denied',
+  collaboration_revoke: 'collaboration_revoke',
+  collaboration_denied: 'collaboration_denied',
   collaboration_edit_request: 'collaboration_edit_request',
   collaboration_edit_approved: 'collaboration_edit_approved',
   collaboration_edit_revoke: 'collaboration_edit_revoke',
@@ -22,7 +23,6 @@ notificationSchemaPlaceholder[
     'A_COLLABORATION_WAS_CREATED_ON_YOUR_BEHALF_MORE_DETAILED',
   showNotificationDialog: false,
   buttonPath: '/#collab-card',
-  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_request
@@ -32,7 +32,6 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'COLLABORATION_VIEW_REQUEST_DESCRIPTION',
   showNotificationDialog: true,
   path: '/view_permission',
-  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_approved
@@ -43,7 +42,6 @@ notificationSchemaPlaceholder[
   showNotificationDialog: false,
   path: '/view_permission',
   buttonPath: '/#collab-card',
-  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_revoke
@@ -53,7 +51,15 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'COLLABORATION_REVOKE_BRIEF',
   showNotificationDialog: false,
   buttonPath: '/#collab-card',
-  notificationAvatar: 'userName',
+};
+notificationSchemaPlaceholder[
+  notificationTypeNames.collaboration_denied
+] = {
+  titleId: 'COLLABORATION_DENIED_TITLE',
+  notificationMessage: 'COLLABORATION_DENIED_BRIEF',
+  moreDetailedDescription: 'COLLABORATION_DENIED_BRIEF',
+  showNotificationDialog: false,
+  buttonPath: '/#collab-card',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_edit_request
@@ -63,7 +69,6 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'COLLABORATION_EDIT_REQUEST_DESCRIPTION',
   showNotificationDialog: true,
   path: '/edit_permission',
-  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_edit_approved
@@ -74,7 +79,6 @@ notificationSchemaPlaceholder[
   showNotificationDialog: false,
   path: '/edit_permission',
   buttonPath: '/#collab-card',
-  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_edit_revoke
@@ -84,7 +88,6 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'EDIT_COLLABORATION_REVOKED',
   showNotificationDialog: false,
   buttonPath: '/#collab-card',
-  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_manager_revoke
@@ -94,7 +97,6 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'COLLABORATION_REVOKED_BY_MANAGER',
   showNotificationDialog: false,
   buttonPath: '/#collab-card',
-  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.individual_merge_request
@@ -104,7 +106,6 @@ notificationSchemaPlaceholder[
   moreDetailedDescription:
     'INDIVIDUAL_MERGE_REQUEST_MESSAGE_DETAILED',
   showNotificationDialog: true,
-  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.individual_merge_complete
@@ -114,7 +115,6 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'INDIVIDUALS_MERGE_COMPLETE_MESSAGE',
   showNotificationDialog: false,
   deriveButtonPath: individualId => `/individuals/${individualId}`,
-  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.individual_merge_blocked
@@ -125,6 +125,5 @@ notificationSchemaPlaceholder[
     'INDIVIDUAL_MERGE_BLOCKED_DETAILED_MESSAGE',
   showNotificationDialog: false,
   deriveButtonPath: individualId => `/individuals/${individualId}`,
-  notificationAvatar: 'userName',
 };
 export const notificationSchema = notificationSchemaPlaceholder;

--- a/src/constants/notificationSchema.js
+++ b/src/constants/notificationSchema.js
@@ -2,7 +2,7 @@ export const notificationTypeNames = {
   collaboration_manager_create: 'collaboration_manager_create',
   collaboration_request: 'collaboration_request',
   collaboration_approved: 'collaboration_approved',
-  collaboration_revoke: 'collaboration_revoke',
+  collaboration_revoke: 'collaboration_denied',
   collaboration_edit_request: 'collaboration_edit_request',
   collaboration_edit_approved: 'collaboration_edit_approved',
   collaboration_edit_revoke: 'collaboration_edit_revoke',
@@ -32,6 +32,7 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'COLLABORATION_VIEW_REQUEST_DESCRIPTION',
   showNotificationDialog: true,
   path: '/view_permission',
+  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_approved
@@ -42,6 +43,7 @@ notificationSchemaPlaceholder[
   showNotificationDialog: false,
   path: '/view_permission',
   buttonPath: '/#collab-card',
+  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_revoke
@@ -51,6 +53,7 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'COLLABORATION_REVOKE_BRIEF',
   showNotificationDialog: false,
   buttonPath: '/#collab-card',
+  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_edit_request
@@ -60,6 +63,7 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'COLLABORATION_EDIT_REQUEST_DESCRIPTION',
   showNotificationDialog: true,
   path: '/edit_permission',
+  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_edit_approved
@@ -70,6 +74,7 @@ notificationSchemaPlaceholder[
   showNotificationDialog: false,
   path: '/edit_permission',
   buttonPath: '/#collab-card',
+  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_edit_revoke
@@ -79,6 +84,7 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'EDIT_COLLABORATION_REVOKED',
   showNotificationDialog: false,
   buttonPath: '/#collab-card',
+  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_manager_revoke
@@ -97,6 +103,7 @@ notificationSchemaPlaceholder[
   moreDetailedDescription:
     'INDIVIDUAL_MERGE_REQUEST_MESSAGE_DETAILED',
   showNotificationDialog: true,
+  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.individual_merge_complete
@@ -106,6 +113,7 @@ notificationSchemaPlaceholder[
   moreDetailedDescription: 'INDIVIDUALS_MERGE_COMPLETE_MESSAGE',
   showNotificationDialog: false,
   deriveButtonPath: individualId => `/individuals/${individualId}`,
+  notificationAvatar: 'userName',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.individual_merge_blocked
@@ -116,5 +124,6 @@ notificationSchemaPlaceholder[
     'INDIVIDUAL_MERGE_BLOCKED_DETAILED_MESSAGE',
   showNotificationDialog: false,
   deriveButtonPath: individualId => `/individuals/${individualId}`,
+  notificationAvatar: 'userName',
 };
 export const notificationSchema = notificationSchemaPlaceholder;

--- a/src/constants/notificationSchema.js
+++ b/src/constants/notificationSchema.js
@@ -22,6 +22,7 @@ notificationSchemaPlaceholder[
     'A_COLLABORATION_WAS_CREATED_ON_YOUR_BEHALF_MORE_DETAILED',
   showNotificationDialog: false,
   buttonPath: '/#collab-card',
+  notificationAvatar: '',
 };
 notificationSchemaPlaceholder[
   notificationTypeNames.collaboration_request

--- a/src/pages/notifications/Notifications.jsx
+++ b/src/pages/notifications/Notifications.jsx
@@ -38,6 +38,8 @@ export default function Notifications() {
     data: notifications,
     loading: notificationsLoading,
   } = useNotifications(true);
+  console.log('deleteMe notifications are: ');
+  console.log(notifications);
 
   const { markRead } = usePatchNotification();
 

--- a/src/pages/notifications/Notifications.jsx
+++ b/src/pages/notifications/Notifications.jsx
@@ -38,8 +38,6 @@ export default function Notifications() {
     data: notifications,
     loading: notificationsLoading,
   } = useNotifications(true);
-  console.log('deleteMe notifications are: ');
-  console.log(notifications);
 
   const { markRead } = usePatchNotification();
 


### PR DESCRIPTION
Adds a notificationAvatar to each notification schema to indicate which variable from NotificationUtils's getNotificationProps to use for gettin the first letter as an Avatar stand-in. 

Also fixes a bug that we missed earlier when collaboration_revoked was changed to collaboration_denied.

QA notes:
Here's what it looked like before (Note all of the "U"s as the avatar):
<img width="1552" alt="Screen Shot 2022-06-13 at 2 17 03 PM" src="https://user-images.githubusercontent.com/2775448/173448131-84ef5597-86fe-4b3c-9157-3541bcd4cc11.png">
<img width="1552" alt="Screen Shot 2022-06-13 at 2 17 51 PM" src="https://user-images.githubusercontent.com/2775448/173448141-5e3c9904-2ffd-4470-a44d-85ca7f0063f4.png">
<img width="1552" alt="Screen Shot 2022-06-13 at 2 17 56 PM" src="https://user-images.githubusercontent.com/2775448/173448145-58fd41c2-e9f1-4a5f-a9f8-179e42076e2b.png">

Here's what is looks like after the fix:
<img width="1552" alt="Screen Shot 2022-06-13 at 2 21 02 PM" src="https://user-images.githubusercontent.com/2775448/173448257-40337d63-56d9-487a-a13d-a46186891fb9.png">
<img width="1552" alt="Screen Shot 2022-06-13 at 2 22 52 PM" src="https://user-images.githubusercontent.com/2775448/173448259-ce6852e0-81ce-46e5-a70c-b03a19537682.png">:
<img width="1552" alt="Screen Shot 2022-06-13 at 2 20 19 PM" src="https://user-images.githubusercontent.com/2775448/173448247-c6c07c43-3613-4901-8b83-18285c7d0e6f.png">


Note that there's about an hour's worth of state built up on unacceptablebehavior.org right now if you log in as user1@example.com with the default password, so you don't have to reproduce all of these notifications yourself.

### Update Jun 14, 2022:

collaboration_denied and
collaboration_revoke

are both accommodated now.
See Jerome Jerome The Metronome and Betty pictured below:
<img width="1552" alt="Screen Shot 2022-06-14 at 11 37 41 AM" src="https://user-images.githubusercontent.com/2775448/173697537-571d6246-abc1-42fc-87e1-dc3597422793.png">
<img width="1552" alt="Screen Shot 2022-06-14 at 11 37 47 AM" src="https://user-images.githubusercontent.com/2775448/173697548-d5950bac-0f94-49eb-8b30-d1898385a422.png">

