### PR TITLE
dex-1178 Update landing page metrics to current zebra values

### DIFF
--- a/src/pages/splash/Metrics.jsx
+++ b/src/pages/splash/Metrics.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedNumber } from 'react-intl';
 import { useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import Grid from '@material-ui/core/Grid';
@@ -10,17 +11,17 @@ import Text from '../../components/Text';
 const metrics = [
   {
     labelId: 'IDENTIFIED_INDIVIDUALS',
-    count: 257,
+    count: 14090,
     icon: IndividualsIcon,
   },
   {
     labelId: 'REPORTED_SIGHTINGS',
-    count: 810,
+    count: 29500,
     icon: SightingsIcon,
   },
   {
     labelId: 'USERS',
-    count: 951,
+    count: 49,
     icon: UsersIcon,
   },
 ];
@@ -70,7 +71,7 @@ export default function Testimonial() {
                   fontSize: isSm ? '1.8rem' : '1.2rem',
                 }}
               >
-                {metric.count}
+                <FormattedNumber value={metric.count} />
               </Text>
               <Text
                 style={{

--- a/src/pages/splash/Metrics.jsx
+++ b/src/pages/splash/Metrics.jsx
@@ -21,7 +21,7 @@ const metrics = [
   },
   {
     labelId: 'USERS',
-    count: 49,
+    count: 37,
     icon: UsersIcon,
   },
 ];


### PR DESCRIPTION
- Updates the hard coded metrics to the current values on zebra.wildme.org:
  -  Identified Individuals - the number of individuals
  - Reported Sightings - the number of asset group sightings plus the number of migrated sightings (sightings without asset group sighting GUIDs)
  - Users - the number of users that are not `internal` an do not have an `@localhost` email address
- Adds `FormattedNumber` so that the counts are formatted.

**NOTE**: This is a temporary fix until these values can be accessed via houston.
<img width="972" alt="metrics" src="https://user-images.githubusercontent.com/50299119/173970499-56a3a985-0b60-49db-9282-0d9d9ce31c48.png">

