### PR TITLE
Dex 1196 id results before available fix

### DIFF
--- a/src/pages/sighting/encounters/Encounters.jsx
+++ b/src/pages/sighting/encounters/Encounters.jsx
@@ -98,6 +98,16 @@ export default function Encounters({
   const encounterFieldSchemas = useEncounterFieldSchemas();
   const encounters = get(sightingData, 'encounters', []);
 
+  const { identification: identificationStep } =
+    sightingData?.pipeline_status || {};
+
+  const {
+    complete: isIdentificationComplete,
+    failed: isIdentificationFailed,
+  } = identificationStep || {};
+  const isIdReady =
+    isIdentificationComplete && !isIdentificationFailed;
+
   useEffect(
     () => {
       const message = vulnerableObject
@@ -222,7 +232,9 @@ export default function Encounters({
           {
             id: 'view-id-results',
             labelId: 'VIEW_IDENTIFICATION_RESULTS',
-            href: `/match-results/${sightingId}`,
+            href: isIdReady
+              ? `/match-results/${sightingId}`
+              : '#overview',
           },
           {
             id: 'create-new-individual',

--- a/src/pages/sighting/encounters/Encounters.jsx
+++ b/src/pages/sighting/encounters/Encounters.jsx
@@ -229,13 +229,13 @@ export default function Encounters({
         ];
 
         const identifyButtonActions = [
-          {
-            id: 'view-id-results',
-            labelId: 'VIEW_IDENTIFICATION_RESULTS',
-            href: isIdReady
-              ? `/match-results/${sightingId}`
-              : '#overview',
-          },
+          isIdReady
+            ? {
+                id: 'view-id-results',
+                labelId: 'VIEW_IDENTIFICATION_RESULTS',
+                href: `/match-results/${sightingId}`,
+              }
+            : {},
           {
             id: 'create-new-individual',
             labelId: 'CREATE_NEW_INDIVIDUAL',

--- a/src/pages/sighting/encounters/Encounters.jsx
+++ b/src/pages/sighting/encounters/Encounters.jsx
@@ -105,9 +105,8 @@ export default function Encounters({
     complete: isIdentificationComplete,
     failed: isIdentificationFailed,
   } = identificationStep || {};
-  // const isIdReady =
-  //   isIdentificationComplete && !isIdentificationFailed; // TODO deleteMe comment back in
-  const isIdReady = false;
+  const isIdReady =
+    isIdentificationComplete && !isIdentificationFailed;
 
   useEffect(
     () => {
@@ -235,7 +234,7 @@ export default function Encounters({
             labelId: 'VIEW_IDENTIFICATION_RESULTS',
             href: isIdReady
               ? `/match-results/${sightingId}`
-              : '#identification-step',
+              : '#overview',
           },
           {
             id: 'create-new-individual',

--- a/src/pages/sighting/encounters/Encounters.jsx
+++ b/src/pages/sighting/encounters/Encounters.jsx
@@ -229,13 +229,15 @@ export default function Encounters({
         ];
 
         const identifyButtonActions = [
-          isIdReady
-            ? {
-                id: 'view-id-results',
-                labelId: 'VIEW_IDENTIFICATION_RESULTS',
-                href: `/match-results/${sightingId}`,
-              }
-            : {},
+          ...(isIdReady
+            ? [
+                {
+                  id: 'view-id-results',
+                  labelId: 'VIEW_IDENTIFICATION_RESULTS',
+                  href: `/match-results/${sightingId}`,
+                },
+              ]
+            : []),
           {
             id: 'create-new-individual',
             labelId: 'CREATE_NEW_INDIVIDUAL',

--- a/src/pages/sighting/encounters/Encounters.jsx
+++ b/src/pages/sighting/encounters/Encounters.jsx
@@ -105,8 +105,9 @@ export default function Encounters({
     complete: isIdentificationComplete,
     failed: isIdentificationFailed,
   } = identificationStep || {};
-  const isIdReady =
-    isIdentificationComplete && !isIdentificationFailed;
+  // const isIdReady =
+  //   isIdentificationComplete && !isIdentificationFailed; // TODO deleteMe comment back in
+  const isIdReady = false;
 
   useEffect(
     () => {
@@ -234,7 +235,7 @@ export default function Encounters({
             labelId: 'VIEW_IDENTIFICATION_RESULTS',
             href: isIdReady
               ? `/match-results/${sightingId}`
-              : '#overview',
+              : '#identification-step',
           },
           {
             id: 'create-new-individual',

--- a/src/pages/sighting/statusCard/StatusCard.jsx
+++ b/src/pages/sighting/statusCard/StatusCard.jsx
@@ -171,7 +171,9 @@ export default function StatusCard({ sightingData }) {
           skippedText={intl.formatMessage({
             id: detectionSkippedLabelId,
           })}
-          failedText={intl.formatMessage({ id: 'DETECTION_FAILED' })}
+          failedText={intl.formatMessage({
+            id: 'DETECTION_FAILED',
+          })}
         />
         <TimelineStep
           Icon={CurationIcon}
@@ -192,7 +194,9 @@ export default function StatusCard({ sightingData }) {
           skippedText={intl.formatMessage({
             id: 'CURATION_SKIPPED_MESSAGE',
           })}
-          failedText={intl.formatMessage({ id: 'CURATION_FAILED' })}
+          failedText={intl.formatMessage({
+            id: 'CURATION_FAILED',
+          })}
         >
           {isCurationInProgress && currentUserHasEditPermission && (
             <div style={{ marginTop: 4, marginBottom: 20 }}>
@@ -214,43 +218,45 @@ export default function StatusCard({ sightingData }) {
             </div>
           )}
         </TimelineStep>
-        <TimelineStep
-          Icon={IdentificationIcon}
-          titleId="IDENTIFICATION"
-          stage={identificationStage}
-          notStartedText={intl.formatMessage({
-            id: 'WAITING_ELLIPSES',
-          })}
-          inProgressText={getProgressText(
-            intl,
-            identificationStartTime,
-          )}
-          finishedText={intl.formatMessage(
-            { id: 'IDENTIFICATION_FINISHED_MESSAGE' },
-            { date: getDateString(identificationEndTime) },
-          )}
-          skippedText={intl.formatMessage({
-            id:
-              assetCount === 0
-                ? 'IDENTIFICATION_SKIPPED_NO_IMAGES_MESSAGE'
-                : 'IDENTIFICATION_SKIPPED_MESSAGE',
-          })}
-          failedText={intl.formatMessage({
-            id: 'IDENTIFICATION_FAILED',
-          })}
-        >
-          {isIdentificationComplete && !isIdentificationFailed && (
-            <div style={{ marginTop: 4 }}>
-              <ButtonLink
-                href={`/match-results/${sightingData?.guid}`}
-                display="panel"
-                size="small"
-              >
-                View match results
-              </ButtonLink>
-            </div>
-          )}
-        </TimelineStep>
+        <a name="identification-step">
+          <TimelineStep
+            Icon={IdentificationIcon}
+            titleId="IDENTIFICATION"
+            stage={identificationStage}
+            notStartedText={intl.formatMessage({
+              id: 'WAITING_ELLIPSES',
+            })}
+            inProgressText={getProgressText(
+              intl,
+              identificationStartTime,
+            )}
+            finishedText={intl.formatMessage(
+              { id: 'IDENTIFICATION_FINISHED_MESSAGE' },
+              { date: getDateString(identificationEndTime) },
+            )}
+            skippedText={intl.formatMessage({
+              id:
+                assetCount === 0
+                  ? 'IDENTIFICATION_SKIPPED_NO_IMAGES_MESSAGE'
+                  : 'IDENTIFICATION_SKIPPED_MESSAGE',
+            })}
+            failedText={intl.formatMessage({
+              id: 'IDENTIFICATION_FAILED',
+            })}
+          >
+            {isIdentificationComplete && !isIdentificationFailed && (
+              <div style={{ marginTop: 4 }}>
+                <ButtonLink
+                  href={`/match-results/${sightingData?.guid}`}
+                  display="panel"
+                  size="small"
+                >
+                  View match results
+                </ButtonLink>
+              </div>
+            )}
+          </TimelineStep>
+        </a>
       </Timeline>
     </Card>
   );

--- a/src/pages/sighting/statusCard/StatusCard.jsx
+++ b/src/pages/sighting/statusCard/StatusCard.jsx
@@ -218,7 +218,7 @@ export default function StatusCard({ sightingData }) {
             </div>
           )}
         </TimelineStep>
-        <a name="identification-step">
+        <section id="identification-step">
           <TimelineStep
             Icon={IdentificationIcon}
             titleId="IDENTIFICATION"
@@ -256,7 +256,7 @@ export default function StatusCard({ sightingData }) {
               </div>
             )}
           </TimelineStep>
-        </a>
+        </section>
       </Timeline>
     </Card>
   );

--- a/src/pages/sighting/statusCard/StatusCard.jsx
+++ b/src/pages/sighting/statusCard/StatusCard.jsx
@@ -218,45 +218,43 @@ export default function StatusCard({ sightingData }) {
             </div>
           )}
         </TimelineStep>
-        <section id="identification-step">
-          <TimelineStep
-            Icon={IdentificationIcon}
-            titleId="IDENTIFICATION"
-            stage={identificationStage}
-            notStartedText={intl.formatMessage({
-              id: 'WAITING_ELLIPSES',
-            })}
-            inProgressText={getProgressText(
-              intl,
-              identificationStartTime,
-            )}
-            finishedText={intl.formatMessage(
-              { id: 'IDENTIFICATION_FINISHED_MESSAGE' },
-              { date: getDateString(identificationEndTime) },
-            )}
-            skippedText={intl.formatMessage({
-              id:
-                assetCount === 0
-                  ? 'IDENTIFICATION_SKIPPED_NO_IMAGES_MESSAGE'
-                  : 'IDENTIFICATION_SKIPPED_MESSAGE',
-            })}
-            failedText={intl.formatMessage({
-              id: 'IDENTIFICATION_FAILED',
-            })}
-          >
-            {isIdentificationComplete && !isIdentificationFailed && (
-              <div style={{ marginTop: 4 }}>
-                <ButtonLink
-                  href={`/match-results/${sightingData?.guid}`}
-                  display="panel"
-                  size="small"
-                >
-                  View match results
-                </ButtonLink>
-              </div>
-            )}
-          </TimelineStep>
-        </section>
+        <TimelineStep
+          Icon={IdentificationIcon}
+          titleId="IDENTIFICATION"
+          stage={identificationStage}
+          notStartedText={intl.formatMessage({
+            id: 'WAITING_ELLIPSES',
+          })}
+          inProgressText={getProgressText(
+            intl,
+            identificationStartTime,
+          )}
+          finishedText={intl.formatMessage(
+            { id: 'IDENTIFICATION_FINISHED_MESSAGE' },
+            { date: getDateString(identificationEndTime) },
+          )}
+          skippedText={intl.formatMessage({
+            id:
+              assetCount === 0
+                ? 'IDENTIFICATION_SKIPPED_NO_IMAGES_MESSAGE'
+                : 'IDENTIFICATION_SKIPPED_MESSAGE',
+          })}
+          failedText={intl.formatMessage({
+            id: 'IDENTIFICATION_FAILED',
+          })}
+        >
+          {isIdentificationComplete && !isIdentificationFailed && (
+            <div style={{ marginTop: 4 }}>
+              <ButtonLink
+                href={`/match-results/${sightingData?.guid}`}
+                display="panel"
+                size="small"
+              >
+                View match results
+              </ButtonLink>
+            </div>
+          )}
+        </TimelineStep>
       </Timeline>
     </Card>
   );

--- a/src/pages/sighting/statusCard/TimelineStep.jsx
+++ b/src/pages/sighting/statusCard/TimelineStep.jsx
@@ -13,6 +13,7 @@ import stages from './stages';
 
 export default function TimelineStep({
   titleId,
+  domId,
   Icon,
   stage,
   notStartedText,
@@ -42,7 +43,7 @@ export default function TimelineStep({
   if (stage === stages.failed) iconColor = theme.palette.error.main;
 
   return (
-    <TimelineItem style={{ minHeight: 100 }}>
+    <TimelineItem style={{ minHeight: 100 }} id={domId}>
       <TimelineSeparator>
         <TimelineDot style={{ backgroundColor: iconColor }}>
           <IconToRender />

--- a/src/pages/sighting/statusCard/TimelineStep.jsx
+++ b/src/pages/sighting/statusCard/TimelineStep.jsx
@@ -13,7 +13,6 @@ import stages from './stages';
 
 export default function TimelineStep({
   titleId,
-  domId,
   Icon,
   stage,
   notStartedText,
@@ -43,7 +42,7 @@ export default function TimelineStep({
   if (stage === stages.failed) iconColor = theme.palette.error.main;
 
   return (
-    <TimelineItem style={{ minHeight: 100 }} id={domId}>
+    <TimelineItem style={{ minHeight: 100 }}>
       <TimelineSeparator>
         <TimelineDot style={{ backgroundColor: iconColor }}>
           <IconToRender />


### PR DESCRIPTION
When match results are not yet ready, clicking "view identification results" from the "Animal" tab's encounter(s) takes the user to the overview tab, where they can see that ID is still in progress/failed.

When match results are ready, the same button takes the user directly to the match results page.

JH mentioned casually in my 1:1 today that ideally he'd want the click to navigate directly to focus on the identification step.
I tried a few things to this effect (e.g., https://github.com/WildMeOrg/codex-frontend/pull/390/commits/d4fe72ca7f900d3d1b7c90b357b86d0b35345e21 and https://github.com/WildMeOrg/codex-frontend/pull/390/commits/1821b907f73cc185099602a2755a55dd90965880), and none of them seemed to work. Open to suggestions.

I'm gonna leave the domId in there even though I didn't end up using it; it's not hurting anything, and we may eventually want it.


Update: June 17 - The ticket was slightly redefined, and I removed domId in accordance with best practice.