### PR TITLE
DEX-1201 update useIndividualTermQuery, useSightingTermQuery, and bui…

### DIFF
--- a/src/models/individual/useIndividualTermQuery.js
+++ b/src/models/individual/useIndividualTermQuery.js
@@ -6,7 +6,7 @@ export default function useIndividualTermQuery(searchTerm) {
     bool: {
       minimum_should_match: 1,
       should: [
-        { match_phrase_prefix: { guid: { query: searchTerm } } },
+        { term: { guid: searchTerm } },
         {
           query_string: {
             query: `*${searchTerm}*`,

--- a/src/models/sighting/useSightingTermQuery.js
+++ b/src/models/sighting/useSightingTermQuery.js
@@ -6,7 +6,7 @@ export default function useSightingTermQuery(searchTerm) {
     bool: {
       minimum_should_match: 1,
       should: [
-        { match_phrase_prefix: { guid: { query: searchTerm } } },
+        { term: { guid: searchTerm } },
         {
           query_string: {
             query: `*${searchTerm}*`,

--- a/src/pages/sighting/identification/buildMatchingSetQuery.js
+++ b/src/pages/sighting/identification/buildMatchingSetQuery.js
@@ -46,7 +46,7 @@ export default function buildMatchingSetQuery(regionSchema, region) {
           bool: {
             minimum_should_match: 1,
             should: matchWithChildren.map(r => ({
-              match_phrase: {
+              term: {
                 locationId: r?.id,
               },
             })),


### PR DESCRIPTION
…ldMatchingSetQuery queries to accommodate the change in type to keyword.

This is the front-end part of the update; it seems to work, but please let me know if there's more to be done.

@brmscheiner this only works for complete guids. Substrings thereof don't match. This seems like something inherent to the keyword type? I don't know if this is desired or even avoidable behavior for a keyword type.

QA Notes:

With recent changes to the back end, the queries were failing with a 400 error:

<img width="1840" alt="Screen Shot 2022-06-20 at 2 49 00 PM" src="https://user-images.githubusercontent.com/2775448/174681742-51bd71c2-47db-4d5d-a098-ef925d87d0b3.png">

Changes to the query syntax seems to fix the issue:

<img width="1552" alt="Screen Shot 2022-06-20 at 2 50 11 PM" src="https://user-images.githubusercontent.com/2775448/174681851-b11cca14-5900-4e3f-aa26-65c51b7f90c3.png">

 