### PR TITLE
fix clearError bug in AddAnnotationsDialog.jsx

### DIFF
--- a/src/pages/sighting/encounters/AddAnnotationsDialog.jsx
+++ b/src/pages/sighting/encounters/AddAnnotationsDialog.jsx
@@ -25,14 +25,14 @@ export default function AddAnnotationsDialog({
     mutate: addAnnotationsToSightingEncounter,
     error: addToSightingEncounterError,
     loading: addToSightingEncounterLoading,
-    onClearError: onClearAddToSightingEncounterError,
+    clearError: onClearAddToSightingEncounterError,
   } = useAddAnnotationsToSightingEncounter();
 
   const {
     mutate: addAnnotationsToAGSEncounter,
     error: addToAGSEncounterError,
     loading: addToAGSEncounterLoading,
-    onClearError: onClearAddToAGSEncounterError,
+    clearError: onClearAddToAGSEncounterError,
   } = useAddAnnotationsToAGSEncounter();
 
   const error = pending

--- a/src/pages/sighting/encounters/MoveAnnotationDialog.jsx
+++ b/src/pages/sighting/encounters/MoveAnnotationDialog.jsx
@@ -33,14 +33,14 @@ export default function MoveAnnotationDialog({
     mutate: addAnnotationsToSightingEncounter,
     error: addToSightingEncounterError,
     loading: addToSightingEncounterLoading,
-    onClearError: onClearAddToSightingEncounterError,
+    clearError: onClearAddToSightingEncounterError,
   } = useAddAnnotationsToSightingEncounter();
 
   const {
     mutate: addAnnotationsToAGSEncounter,
     error: addToAGSEncounterError,
     loading: addToAGSEncounterLoading,
-    onClearError: onClearAddToAGSEncounterError,
+    clearError: onClearAddToAGSEncounterError,
   } = useAddAnnotationsToAGSEncounter();
 
   const error = pending


### PR DESCRIPTION
Just a bug fix that I found along the way and was a quick fix.

QA notes: view-only collaborators shouldn't be able to do EDITy things on another user's sighting. But they _should_ be able to dismiss the dialog box telling them as much:

<img width="1552" alt="Screen Shot 2022-06-21 at 1 52 30 PM" src="https://user-images.githubusercontent.com/2775448/174895303-11a186ac-08c4-4d58-9a8a-87cafd644771.png">

