### PR TITLE
dex 1178 - fetch front page metrics from houston

### DIFF
--- a/src/constants/queryKeys.js
+++ b/src/constants/queryKeys.js
@@ -11,6 +11,7 @@ export default {
   allNotifications: 'allNotifications',
   unreadNotifications: 'unreadNotifications',
   twitterBotTestResults: 'twitterBotTestResults',
+  publicData: 'publicData',
 };
 
 export function getAuditLogQueryKey(guid) {

--- a/src/models/site/usePublicData.js
+++ b/src/models/site/usePublicData.js
@@ -1,0 +1,9 @@
+import useFetch from '../../hooks/useFetch';
+import queryKeys from '../../constants/queryKeys';
+
+export default function usePublicData() {
+  return useFetch({
+    queryKey: queryKeys.publicData,
+    url: '/site-settings/public-data',
+  });
+}

--- a/src/pages/splash/Metrics.jsx
+++ b/src/pages/splash/Metrics.jsx
@@ -1,34 +1,56 @@
 import React from 'react';
 import { FormattedNumber } from 'react-intl';
+import { isNil } from 'lodash-es';
+
 import { useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import Grid from '@material-ui/core/Grid';
 import UsersIcon from '@material-ui/icons/People';
 import SightingsIcon from '@material-ui/icons/PhotoCamera';
 import IndividualsIcon from '@material-ui/icons/Fingerprint';
+
 import Text from '../../components/Text';
+import usePublicData from '../../models/site/usePublicData';
 
-const metrics = [
-  {
-    labelId: 'IDENTIFIED_INDIVIDUALS',
-    count: 14090,
-    icon: IndividualsIcon,
-  },
-  {
-    labelId: 'REPORTED_SIGHTINGS',
-    count: 29500,
-    icon: SightingsIcon,
-  },
-  {
-    labelId: 'USERS',
-    count: 37,
-    icon: UsersIcon,
-  },
-];
+function getMetrics(data) {
+  const {
+    num_sightings: numSightings,
+    num_pending_sightings: numPendingSightings,
+  } = data || {};
 
-export default function Testimonial() {
+  let numReportedSightings;
+  if (!isNil(numSightings)) {
+    numReportedSightings = isNil(numPendingSightings)
+      ? numSightings
+      : numSightings + numPendingSightings;
+  } else if (!isNil(numPendingSightings)) {
+    numReportedSightings = numPendingSightings;
+  }
+
+  return [
+    {
+      labelId: 'IDENTIFIED_INDIVIDUALS',
+      count: data?.num_individuals,
+      icon: IndividualsIcon,
+    },
+    {
+      labelId: 'REPORTED_SIGHTINGS',
+      count: numReportedSightings,
+      icon: SightingsIcon,
+    },
+    {
+      labelId: 'USERS',
+      count: data?.num_users,
+      icon: UsersIcon,
+    },
+  ];
+}
+
+export default function Metrics() {
   const theme = useTheme();
   const isSm = useMediaQuery(theme.breakpoints.down('sm'));
+  const { data } = usePublicData();
+  const metrics = getMetrics(data);
 
   return (
     <div
@@ -49,42 +71,44 @@ export default function Testimonial() {
           color: theme.palette.common.white,
         }}
       >
-        {metrics.map(metric => (
-          <Grid
-            item
-            style={{
-              display: 'flex',
-              margin: '32px 0',
-              flexDirection: isSm ? 'column' : 'row',
-              alignItems: 'center',
-            }}
-          >
-            <metric.icon
-              style={{ fontSize: 52, marginRight: isSm ? 0 : 12 }}
-            />
-            <div style={{ textAlign: isSm ? 'center' : 'unset' }}>
-              <Text
-                style={{
-                  color: theme.palette.primary.main,
-                  fontWeight: 800,
-                  letterSpacing: '0.02em',
-                  fontSize: isSm ? '1.8rem' : '1.2rem',
-                }}
-              >
-                <FormattedNumber value={metric.count} />
-              </Text>
-              <Text
-                style={{
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.02em',
-                  fontSize: 14,
-                  fontWeight: 400,
-                }}
-                id={metric.labelId}
+        {metrics
+          .filter(metric => !isNil(metric.count))
+          .map(metric => (
+            <Grid
+              item
+              style={{
+                display: 'flex',
+                margin: '32px 0',
+                flexDirection: isSm ? 'column' : 'row',
+                alignItems: 'center',
+              }}
+            >
+              <metric.icon
+                style={{ fontSize: 52, marginRight: isSm ? 0 : 12 }}
               />
-            </div>
-          </Grid>
-        ))}
+              <div style={{ textAlign: isSm ? 'center' : 'unset' }}>
+                <Text
+                  style={{
+                    color: theme.palette.primary.main,
+                    fontWeight: 800,
+                    letterSpacing: '0.02em',
+                    fontSize: isSm ? '1.8rem' : '1.2rem',
+                  }}
+                >
+                  <FormattedNumber value={metric.count} />
+                </Text>
+                <Text
+                  style={{
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.02em',
+                    fontSize: 14,
+                    fontWeight: 400,
+                  }}
+                  id={metric.labelId}
+                />
+              </div>
+            </Grid>
+          ))}
       </Grid>
     </div>
   );


### PR DESCRIPTION
- Populates the front page metrics with data from houston instead of hard coded values.
  - If a metric's count is null or undefined, then it is not displayed. If all metric counts are undefined or null, including when they are loading, then only a theme colored line displays.
<img width="1039" alt="no-metrics" src="https://user-images.githubusercontent.com/50299119/174920720-d2352c21-c8dc-43ee-94c6-eeefaf144378.png">

The diff looks slightly worse than it really is because the filter of null or undefined metrics caused the nested code to indent further than previously.
