### PR TITLE
dex 1027 - filter out match results without annotations

### DIFF
--- a/src/pages/match/MatchSighting.jsx
+++ b/src/pages/match/MatchSighting.jsx
@@ -99,17 +99,26 @@ export default function MatchSighting() {
         ['algorithms', 'hotspotter_nosv', 'scores_by_annotation'],
         [],
       );
-      return hotspotterAnnotationScores.map((scoreObject, index) => {
-        const matchingAnnotation = get(matchResults, [
+
+      function findMatchingAnnotation(scoreObject) {
+        return get(matchResults, [
           'annotation_data',
           scoreObject?.guid,
         ]);
-        return {
-          ...matchingAnnotation,
-          ...scoreObject,
-          index,
-        };
-      });
+      }
+
+      return hotspotterAnnotationScores
+        .filter(findMatchingAnnotation)
+        .map((scoreObject, index) => {
+          const matchingAnnotation = findMatchingAnnotation(
+            scoreObject,
+          );
+          return {
+            ...matchingAnnotation,
+            ...scoreObject,
+            index,
+          };
+        });
     },
     [matchResults, selectedQueryAnnotation],
   );


### PR DESCRIPTION
- Prevents a row from rendering for the match results if the `annotation_data` for the `/id_result` response does not include the annotation.
  - hot spotter includes results for annotations that houston has filtered out because they are not associated with an encounter.