### PR TITLE
DEX-1000 replace isSuccess with success and utilize clearSuccess to r…

### DIFF
--- a/src/pages/sighting/encounters/ManuallyAssignModal.jsx
+++ b/src/pages/sighting/encounters/ManuallyAssignModal.jsx
@@ -18,9 +18,10 @@ export default function ManuallyAssignModal({
 }) {
   const {
     mutate: assignEncounters,
-    isSuccess,
+    success,
     loading,
     error,
+    clearSuccess,
   } = useAssignEncountersToIndividual();
 
   const [
@@ -31,21 +32,20 @@ export default function ManuallyAssignModal({
   const onCloseDialog = () => {
     setSelectedIndividualGuid(null);
     onClose();
+    clearSuccess();
   };
 
   return (
     <StandardDialog
-      maxWidth={isSuccess ? 'sm' : 'xl'}
+      maxWidth={success ? 'sm' : 'xl'}
       titleId={
-        isSuccess
-          ? 'CLUSTER_ASSIGNED'
-          : 'ASSIGN_CLUSTER_TO_INDIVIDUAL'
+        success ? 'CLUSTER_ASSIGNED' : 'ASSIGN_CLUSTER_TO_INDIVIDUAL'
       }
       open={open}
       onClose={onCloseDialog}
     >
       <DialogContent>
-        {isSuccess ? (
+        {success ? (
           <Text id="ASSIGN_CLUSTER_TO_INDIVIDUAL_DESCRIPTION" />
         ) : (
           <IndividualSelector
@@ -66,9 +66,9 @@ export default function ManuallyAssignModal({
         <Button
           display="basic"
           onClick={onCloseDialog}
-          id={isSuccess ? 'CLOSE' : 'CANCEL'}
+          id={success ? 'CLOSE' : 'CANCEL'}
         />
-        {isSuccess ? (
+        {success ? (
           <ButtonLink
             id="VIEW_INDIVIDUAL"
             display="primary"


### PR DESCRIPTION
…emove success state upon dialog dismissal

QA notes:

Before, when you tried to assign the second encounter of a sighting to an individual, it was all:
<img width="1840" alt="Screen Shot 2022-06-23 at 10 47 58 AM" src="https://user-images.githubusercontent.com/2775448/175362347-2b718a5b-5b9f-4c23-b550-7f7329e54c82.png">

But, now, it be like:

<img width="1840" alt="Screen Shot 2022-06-23 at 10 48 34 AM" src="https://user-images.githubusercontent.com/2775448/175362453-94cb5e4c-3608-408e-bf19-833b94c6c976.png">

