### PR TITLE
dex 1121 - pipeline status improvements

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -151,6 +151,7 @@
   "WAITING_ELLIPSES": "Waiting...",
   "CURATION_ASSIGN_ANNOTATIONS": "Assign annotations",
   "CURATION_ANNOTATE_PHOTOS": "Annotate photographs",
+  "IDENTIFICATION_VIEW_RESULTS": "View match results",
   "REPORTED_BY": "Reported by ",
   "GENERAL_SETTINGS": "General settings",
   "ONE_SIGHTING_TOGGLE_DESCRIPTION": "This sighting has only one individual and I would like to report metadata about it now.",

--- a/src/pages/sighting/encounters/Encounters.jsx
+++ b/src/pages/sighting/encounters/Encounters.jsx
@@ -98,15 +98,11 @@ export default function Encounters({
   const encounterFieldSchemas = useEncounterFieldSchemas();
   const encounters = get(sightingData, 'encounters', []);
 
-  const { identification: identificationStep } =
-    sightingData?.pipeline_status || {};
-
-  const {
-    complete: isIdentificationComplete,
-    failed: isIdentificationFailed,
-  } = identificationStep || {};
-  const isIdReady =
-    isIdentificationComplete && !isIdentificationFailed;
+  const isIdentificationComplete = get(
+    sightingData,
+    'pipeline_status.identification.complete',
+    false,
+  );
 
   useEffect(
     () => {
@@ -229,7 +225,7 @@ export default function Encounters({
         ];
 
         const identifyButtonActions = [
-          ...(isIdReady
+          ...(isIdentificationComplete
             ? [
                 {
                   id: 'view-id-results',

--- a/src/pages/sighting/encounters/Encounters.jsx
+++ b/src/pages/sighting/encounters/Encounters.jsx
@@ -98,11 +98,15 @@ export default function Encounters({
   const encounterFieldSchemas = useEncounterFieldSchemas();
   const encounters = get(sightingData, 'encounters', []);
 
-  const isIdentificationComplete = get(
-    sightingData,
-    'pipeline_status.identification.complete',
-    false,
-  );
+  const { identification: identificationStep } =
+    sightingData?.pipeline_status || {};
+
+  const {
+    complete: isIdentificationComplete,
+    failed: isIdentificationFailed,
+  } = identificationStep || {};
+  const isIdReady =
+    isIdentificationComplete && !isIdentificationFailed;
 
   useEffect(
     () => {
@@ -225,7 +229,7 @@ export default function Encounters({
         ];
 
         const identifyButtonActions = [
-          ...(isIdentificationComplete
+          ...(isIdReady
             ? [
                 {
                   id: 'view-id-results',

--- a/src/pages/sighting/statusCard/StatusCard.jsx
+++ b/src/pages/sighting/statusCard/StatusCard.jsx
@@ -145,6 +145,7 @@ export default function StatusCard({ sightingData }) {
     start: identificationStartTime,
     end: identificationEndTime,
     complete: isIdentificationComplete,
+    failed: isIdentificationFailed,
     message: identificationMessage,
   } = identificationStep || {};
 
@@ -283,7 +284,7 @@ export default function StatusCard({ sightingData }) {
           })}
           failedAlertDescription={identificationMessage}
         >
-          {isIdentificationComplete && (
+          {isIdentificationComplete && !isIdentificationFailed && (
             <div style={{ marginTop: 4 }}>
               <ButtonLink
                 id="IDENTIFICATION_VIEW_RESULTS"

--- a/src/pages/sighting/statusCard/StatusCard.jsx
+++ b/src/pages/sighting/statusCard/StatusCard.jsx
@@ -50,10 +50,9 @@ function getStage(pipelineStep) {
 
   if (inProgress) return stages.current;
 
-  if (complete) {
-    if (failed) return stages.failed;
-    return stages.finished;
-  }
+  if (failed) return stages.failed;
+
+  if (complete) return stages.finished;
 
   return stages.waiting;
 }
@@ -139,7 +138,6 @@ export default function StatusCard({ sightingData }) {
     start: identificationStartTime,
     end: identificationEndTime,
     complete: isIdentificationComplete,
-    failed: isIdentificationFailed,
   } = identificationStep || {};
 
   const identificationStage = getStage(identificationStep);
@@ -277,7 +275,7 @@ export default function StatusCard({ sightingData }) {
             id: 'IDENTIFICATION_FAILED',
           })}
         >
-          {isIdentificationComplete && !isIdentificationFailed && (
+          {isIdentificationComplete && (
             <div style={{ marginTop: 4 }}>
               <ButtonLink
                 href={`/match-results/${sightingData?.guid}`}

--- a/src/pages/sighting/statusCard/StatusCard.jsx
+++ b/src/pages/sighting/statusCard/StatusCard.jsx
@@ -286,12 +286,11 @@ export default function StatusCard({ sightingData }) {
           {isIdentificationComplete && (
             <div style={{ marginTop: 4 }}>
               <ButtonLink
+                id="IDENTIFICATION_VIEW_RESULTS"
                 href={`/match-results/${sightingData?.guid}`}
                 display="panel"
                 size="small"
-              >
-                View match results
-              </ButtonLink>
+              />
             </div>
           )}
         </TimelineStep>

--- a/src/pages/sighting/statusCard/StatusCard.jsx
+++ b/src/pages/sighting/statusCard/StatusCard.jsx
@@ -87,13 +87,19 @@ export default function StatusCard({ sightingData }) {
     migrated,
   } = sightingData?.pipeline_status || {};
 
-  const { start: preparationStartTime, end: preparationEndTime } =
-    preparationStep || {};
+  const {
+    start: preparationStartTime,
+    end: preparationEndTime,
+    message: preparationMessage,
+  } = preparationStep || {};
 
   const preparationStage = getStage(preparationStep);
 
-  const { start: detectionStartTime, end: detectionEndTime } =
-    detectionStep || {};
+  const {
+    start: detectionStartTime,
+    end: detectionEndTime,
+    message: detectionMessage,
+  } = detectionStep || {};
 
   const detectionStage = getStage(detectionStep);
   let detectionSkippedLabelId = 'DETECTION_SKIPPED_MESSAGE';
@@ -109,6 +115,7 @@ export default function StatusCard({ sightingData }) {
     start: curationStartTime,
     end: curationEndTime,
     inProgress: isCurationInProgress,
+    message: curationMessage,
   } = curationStep || {};
 
   const curationStage = getStage(curationStep);
@@ -138,6 +145,7 @@ export default function StatusCard({ sightingData }) {
     start: identificationStartTime,
     end: identificationEndTime,
     complete: isIdentificationComplete,
+    message: identificationMessage,
   } = identificationStep || {};
 
   const identificationStage = getStage(identificationStep);
@@ -195,6 +203,7 @@ export default function StatusCard({ sightingData }) {
           failedText={intl.formatMessage({
             id: 'SIGHTING_PREPARATION_FAILED',
           })}
+          failedAlertDescription={preparationMessage}
         />
         <TimelineStep
           Icon={DetectionIcon}
@@ -211,9 +220,8 @@ export default function StatusCard({ sightingData }) {
           skippedText={intl.formatMessage({
             id: detectionSkippedLabelId,
           })}
-          failedText={intl.formatMessage({
-            id: 'DETECTION_FAILED',
-          })}
+          failedText={intl.formatMessage({ id: 'DETECTION_FAILED' })}
+          failedAlertDescription={detectionMessage}
         />
         <TimelineStep
           Icon={CurationIcon}
@@ -231,9 +239,8 @@ export default function StatusCard({ sightingData }) {
           skippedText={intl.formatMessage({
             id: 'CURATION_SKIPPED_MESSAGE',
           })}
-          failedText={intl.formatMessage({
-            id: 'CURATION_FAILED',
-          })}
+          failedText={intl.formatMessage({ id: 'CURATION_FAILED' })}
+          failedAlertDescription={curationMessage}
         >
           {isCurationInProgress && currentUserHasEditPermission && (
             <div style={{ marginTop: 4, marginBottom: 20 }}>
@@ -274,6 +281,7 @@ export default function StatusCard({ sightingData }) {
           failedText={intl.formatMessage({
             id: 'IDENTIFICATION_FAILED',
           })}
+          failedAlertDescription={identificationMessage}
         >
           {isIdentificationComplete && (
             <div style={{ marginTop: 4 }}>

--- a/src/pages/sighting/statusCard/TimelineStep.jsx
+++ b/src/pages/sighting/statusCard/TimelineStep.jsx
@@ -7,7 +7,7 @@ import TimelineContent from '@material-ui/lab/TimelineContent';
 import TimelineDot from '@material-ui/lab/TimelineDot';
 import ProgressIcon from '@material-ui/icons/Cached';
 import ErrorIcon from '@material-ui/icons/PriorityHigh';
-
+import CustomAlert from '../../../components/Alert';
 import Text from '../../../components/Text';
 import stages from './stages';
 
@@ -20,6 +20,7 @@ export default function TimelineStep({
   finishedText,
   skippedText,
   failedText,
+  failedAlertDescription,
   children,
 }) {
   const theme = useTheme();
@@ -51,6 +52,13 @@ export default function TimelineStep({
       <TimelineContent>
         <Text variant="h6" id={titleId} />
         <Text variant="caption">{descriptionText}</Text>
+        {stage === stages.failed && failedAlertDescription && (
+          <CustomAlert
+            description={failedAlertDescription}
+            severity="error"
+            style={{ marginTop: '4px' }}
+          />
+        )}
         {children}
       </TimelineContent>
     </TimelineItem>


### PR DESCRIPTION
- Redefines a "complete" status so that "failed" is no longer a sub-state of "complete"
- Internationalizes "View Match Results" button.
- Adds an alert within the timeline step if the step has failed.
<img width="609" alt=" error-message" src="https://user-images.githubusercontent.com/50299119/175363650-9a3fa3a3-dde7-4f88-9802-2c36712002a0.png">


This is related to WildMeOrg/houston#693