### PR TITLE
DEX-1030 and DEX-1029 change/add sortNames to firstName in individual…

### DIFF
--- a/src/components/dataDisplays/IndividualsDisplay.jsx
+++ b/src/components/dataDisplays/IndividualsDisplay.jsx
@@ -20,9 +20,9 @@ export default function IndividualsDisplay({
   const columns = [
     {
       name: 'firstName',
-      sortName: 'firstName',
+      sortName: 'elasticsearch.firstName_keyword',
       labelId: 'NAME',
-      sortable: false,
+      sortable: true,
       options: {
         customBodyRender: (firstName, individual) => (
           <Link to={`/individuals/${individual?.guid}`}>

--- a/src/components/dataDisplays/SightingsDisplay.jsx
+++ b/src/components/dataDisplays/SightingsDisplay.jsx
@@ -44,8 +44,9 @@ export default function SightingsDisplay({
     },
     {
       name: 'locationId_value',
+      sortName: 'elasticsearch.locationId_keyword',
       labelId: 'REGION',
-      sortable: false,
+      sortable: true,
       align: 'left',
     },
     {


### PR DESCRIPTION
… and locationId in sighting

QA notes:

Individual search page should now be sortable by first name:
<img width="1840" alt="Screen Shot 2022-06-23 at 3 51 12 PM" src="https://user-images.githubusercontent.com/2775448/175427840-632b7742-2b5b-4cfd-a7b4-f74d90337d19.png">

And sighting search page should now be sortable by region:
<img width="1840" alt="Screen Shot 2022-06-23 at 3 51 35 PM" src="https://user-images.githubusercontent.com/2775448/175427885-d72cf55e-9597-4bdd-a111-d7ddcc882384.png">

