### PR TITLE
dex 967 - fix sighting UI when preparation fails

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -137,6 +137,8 @@
   "IMAGE_PROCESSING_ERROR": "Image processing error",
   "IMAGE_PROCESSING_ERROR_MESSAGE": "An unknown error has occurred; delete and rerun this import. If this problem occurs again, report this error on the Community Forums.",
   "HISTORY": "History",
+  "SIGHTING_PREPARATION_ALERT_TITLE": "This sighting has not finished processing",
+  "SIGHTING_PREPARATION_ALERT_MESSAGE": "Until this step is complete, images cannot be viewed and some functionality is unavailable.",
   "SIGHTING_PREPARATION_SKIPPED_MESSAGE": "Sighting preparation skipped.",
   "DETECTION_SKIPPED_MESSAGE": "Detection skipped.",
   "DETECTION_SKIPPED_NO_IMAGES_MESSAGE": "Detection skipped - no images to annotate.",

--- a/src/pages/sighting/SightingCore.jsx
+++ b/src/pages/sighting/SightingCore.jsx
@@ -88,12 +88,16 @@ export default function SightingCore({
   // const [historyOpen, setHistoryOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
-  const isPreparationInProgress = get(
+  /*
+  Preparation can never be skipped, even when there are no images,
+  so that case can be ignored.
+  */
+  const isPreparationComplete = get(
     data,
-    'pipeline_status.preparation.inProgress',
+    'pipeline_status.preparation.complete',
   );
 
-  const activeTab = isPreparationInProgress
+  const activeTab = !isPreparationComplete
     ? sightingTabs['#overview']
     : sightingTabs[window.location.hash] || sightingTabs['#overview'];
 
@@ -170,12 +174,12 @@ export default function SightingCore({
         data={data}
         loading={loading}
         pending={pending}
-        preparing={isPreparationInProgress}
+        preparing={!isPreparationComplete}
         guid={id}
         // setHistoryOpen={setHistoryOpen}
         setDeleteDialogOpen={setDeleteDialogOpen}
       />
-      {isPreparationInProgress ? (
+      {!isPreparationComplete ? (
         <CustomAlert
           titleId="PENDING_IMAGE_PROCESSING"
           descriptionId="PENDING_IMAGE_PROCESSING_MESSAGE"

--- a/src/pages/sighting/SightingCore.jsx
+++ b/src/pages/sighting/SightingCore.jsx
@@ -181,8 +181,8 @@ export default function SightingCore({
       />
       {!isPreparationComplete ? (
         <CustomAlert
-          titleId="PENDING_IMAGE_PROCESSING"
-          descriptionId="PENDING_IMAGE_PROCESSING_MESSAGE"
+          titleId="SIGHTING_PREPARATION_ALERT_TITLE"
+          descriptionId="SIGHTING_PREPARATION_ALERT_MESSAGE"
           severity="info"
           style={{ marginBottom: 24 }}
         />


### PR DESCRIPTION
Pull request checklist:
 - [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
 - [x] All text is internationalized
 - [x] There are no linter errors
 - [x] New features support all states (loading, error, etc) (**N/A**)

# Summary
## Bug
The sighting UI uses the minimal, overview only layout while Sighting Preparation is in progress. However, if the preparation stage fails, the full layout is used and the alert displays the incorrect information.

<img width="990" alt="current" src="https://user-images.githubusercontent.com/50299119/176753760-d06f9177-8ecd-4fe6-a9f9-d7e671121508.png">

## Changes
- Updates the logic to use the minimal layout until the preparation stage is complete.
- Updates the alert title so that it makes sense for both the inProgress and failed states.
  - This is currently how the alert works when detection fails.

| in progress | error |
| :---: | :---: |
| <img width="982" alt="alert-in-progress" src="https://user-images.githubusercontent.com/50299119/176755145-fb5f3093-9bf7-469b-9de0-1ad079b1917d.png"> | <img width="982" alt="alert-error" src="https://user-images.githubusercontent.com/50299119/176755167-66f5db87-f3ce-4143-ac68-ec62de0cf5b5.png"> |