### PR TITLE
DEX-1270 remove id from optionEditor

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1128,5 +1128,5 @@
   "PAGINATION_LAST_PAGE": "last page",
   "PAGINATION_PREVIOUS_PAGE": "previous page",
   "PAGINATION_NEXT_PAGE": "next page",
-  "UNFINISHED_OPTIONS": "Options must have valid values and labels"
+  "UNFINISHED_OPTIONS": "Options must have valid values and labels and unique values"
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -1127,5 +1127,6 @@
   "PAGINATION_FIRST_PAGE": "first page",
   "PAGINATION_LAST_PAGE": "last page",
   "PAGINATION_PREVIOUS_PAGE": "previous page",
-  "PAGINATION_NEXT_PAGE": "next page"
+  "PAGINATION_NEXT_PAGE": "next page",
+  "UNFINISHED_OPTIONS": "Options must have valid values and labels"
 }

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -137,46 +137,18 @@ const Core = function (
 };
 
 const ButtonWithTooltip = function (
-  {
-    showTooltip = false,
-    tooltipText = '',
-    display = 'panel',
-    loading = false,
-    style,
-    disabled,
-    size,
-    ...rest
-  },
+  { showTooltip = false, tooltipText = '', ...rest },
   ref,
 ) {
   if (showTooltip)
     return (
       <Tooltip title={tooltipText}>
         <span>
-          <CoreForwardRef
-            display={display}
-            loading={loading}
-            style={style}
-            disabled={disabled}
-            size={size}
-            ref={ref}
-            {...rest}
-          />
+          <CoreForwardRef ref={ref} {...rest} />
         </span>
       </Tooltip>
     );
-  else
-    return (
-      <CoreForwardRef
-        display={display}
-        loading={loading}
-        style={style}
-        disabled={disabled}
-        size={size}
-        ref={ref}
-        {...rest}
-      />
-    );
+  else return <CoreForwardRef ref={ref} {...rest} />;
 };
 
 const CoreForwardRef = forwardRef(Core);

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -138,12 +138,12 @@ const Core = function (
 
 const ButtonWithTooltip = function (
   {
+    showTooltip = false,
+    tooltipText = '',
     display = 'panel',
     loading = false,
     style,
     disabled,
-    showTooltip = false,
-    tooltipText = '',
     size,
     ...rest
   },

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useTheme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import BackIcon from '@material-ui/icons/KeyboardBackspace';
 
@@ -12,6 +13,7 @@ const Core = function (
     loading = false,
     style,
     disabled,
+    tooltiptext = '',
     size,
     ...rest
   },
@@ -28,19 +30,23 @@ const Core = function (
 
   if (display === 'back') {
     return (
-      <Button
-        size="small"
-        startIcon={<BackIcon />}
-        disabled={disabled}
-        style={{
-          padding: '4px 16px',
-          ...style,
-        }}
-        ref={ref}
-        {...rest}
-      >
-        {children}
-      </Button>
+      <Tooltip title={tooltiptext}>
+        <span>
+          <Button
+            size="small"
+            startIcon={<BackIcon />}
+            disabled={disabled}
+            style={{
+              padding: '4px 16px',
+              ...style,
+            }}
+            ref={ref}
+            {...rest}
+          >
+            {children}
+          </Button>
+        </span>
+      </Tooltip>
     );
   }
 
@@ -97,18 +103,22 @@ const Core = function (
       fontSize: '14px',
     };
     return (
-      <button
-        type="button"
-        style={{ ...roleStyles, ...style }}
-        ref={ref}
-        {...rest}
-      >
-        {loading ? (
-          <CircularProgress size={24} style={spinnerStyles} />
-        ) : (
-          children
-        )}
-      </button>
+      <Tooltip title={tooltiptext}>
+        <span>
+          <button
+            type="button"
+            style={{ ...roleStyles, ...style }}
+            ref={ref}
+            {...rest}
+          >
+            {loading ? (
+              <CircularProgress size={24} style={spinnerStyles} />
+            ) : (
+              children
+            )}
+          </button>
+        </span>
+      </Tooltip>
     );
   }
 
@@ -118,21 +128,25 @@ const Core = function (
   }
 
   return (
-    <Button
-      color={color}
-      variant={variant}
-      disabled={disabled}
-      style={{ ...roleStyles, ...style }}
-      size={size}
-      ref={ref}
-      {...rest}
-    >
-      {loading ? (
-        <CircularProgress size={24} style={spinnerStyles} />
-      ) : (
-        children
-      )}
-    </Button>
+    <Tooltip title={tooltiptext}>
+      <span>
+        <Button
+          color={color}
+          variant={variant}
+          disabled={disabled}
+          style={{ ...roleStyles, ...style }}
+          size={size}
+          ref={ref}
+          {...rest}
+        >
+          {loading ? (
+            <CircularProgress size={24} style={spinnerStyles} />
+          ) : (
+            children
+          )}
+        </Button>
+      </span>
+    </Tooltip>
   );
 };
 

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -13,7 +13,6 @@ const Core = function (
     loading = false,
     style,
     disabled,
-    tooltiptext = '',
     size,
     ...rest
   },
@@ -27,26 +26,21 @@ const Core = function (
   let spinnerStyles = {
     color: theme.palette.common.white,
   };
-
   if (display === 'back') {
     return (
-      <Tooltip title={tooltiptext}>
-        <span>
-          <Button
-            size="small"
-            startIcon={<BackIcon />}
-            disabled={disabled}
-            style={{
-              padding: '4px 16px',
-              ...style,
-            }}
-            ref={ref}
-            {...rest}
-          >
-            {children}
-          </Button>
-        </span>
-      </Tooltip>
+      <Button
+        size="small"
+        startIcon={<BackIcon />}
+        disabled={disabled}
+        style={{
+          padding: '4px 16px',
+          ...style,
+        }}
+        ref={ref}
+        {...rest}
+      >
+        {children}
+      </Button>
     );
   }
 
@@ -103,22 +97,18 @@ const Core = function (
       fontSize: '14px',
     };
     return (
-      <Tooltip title={tooltiptext}>
-        <span>
-          <button
-            type="button"
-            style={{ ...roleStyles, ...style }}
-            ref={ref}
-            {...rest}
-          >
-            {loading ? (
-              <CircularProgress size={24} style={spinnerStyles} />
-            ) : (
-              children
-            )}
-          </button>
-        </span>
-      </Tooltip>
+      <button
+        type="button"
+        style={{ ...roleStyles, ...style }}
+        ref={ref}
+        {...rest}
+      >
+        {loading ? (
+          <CircularProgress size={24} style={spinnerStyles} />
+        ) : (
+          children
+        )}
+      </button>
     );
   }
 
@@ -128,29 +118,70 @@ const Core = function (
   }
 
   return (
-    <Tooltip title={tooltiptext}>
-      <span>
-        <Button
-          color={color}
-          variant={variant}
-          disabled={disabled}
-          style={{ ...roleStyles, ...style }}
-          size={size}
-          ref={ref}
-          {...rest}
-        >
-          {loading ? (
-            <CircularProgress size={24} style={spinnerStyles} />
-          ) : (
-            children
-          )}
-        </Button>
-      </span>
-    </Tooltip>
+    <Button
+      color={color}
+      variant={variant}
+      disabled={disabled}
+      style={{ ...roleStyles, ...style }}
+      size={size}
+      ref={ref}
+      {...rest}
+    >
+      {loading ? (
+        <CircularProgress size={24} style={spinnerStyles} />
+      ) : (
+        children
+      )}
+    </Button>
   );
 };
 
+const ButtonWithTooltip = function (
+  {
+    display = 'panel',
+    loading = false,
+    style,
+    disabled,
+    showTooltip = false,
+    tooltipText = '',
+    size,
+    ...rest
+  },
+  ref,
+) {
+  if (showTooltip)
+    return (
+      <Tooltip title={tooltipText}>
+        <span>
+          <CoreForwardRef
+            display={display}
+            loading={loading}
+            style={style}
+            disabled={disabled}
+            size={size}
+            ref={ref}
+            {...rest}
+          />
+        </span>
+      </Tooltip>
+    );
+  else
+    return (
+      <CoreForwardRef
+        display={display}
+        loading={loading}
+        style={style}
+        disabled={disabled}
+        size={size}
+        ref={ref}
+        {...rest}
+      />
+    );
+};
+
 const CoreForwardRef = forwardRef(Core);
+
+const ButtonForwardRef = forwardRef(ButtonWithTooltip);
 
 function CustomButton(
   { id, domId = undefined, values, children, ...rest },
@@ -158,14 +189,14 @@ function CustomButton(
 ) {
   if (!id)
     return (
-      <CoreForwardRef id={domId} ref={ref} {...rest}>
+      <ButtonForwardRef id={domId} ref={ref} {...rest}>
         {children}
-      </CoreForwardRef>
+      </ButtonForwardRef>
     );
   return (
-    <CoreForwardRef id={domId} ref={ref} {...rest}>
+    <ButtonForwardRef id={domId} ref={ref} {...rest}>
       <FormattedMessage id={id} values={values} />
-    </CoreForwardRef>
+    </ButtonForwardRef>
   );
 }
 

--- a/src/pages/fieldManagement/settings/saveField/OptionEditor.jsx
+++ b/src/pages/fieldManagement/settings/saveField/OptionEditor.jsx
@@ -133,7 +133,7 @@ export default function OptionEditor({
       <DialogActions style={{ padding: '0px 24px 24px 24px' }}>
         <Button
           disabled={!areAllOptionsValid}
-          showTooltip
+          showTooltip={!areAllOptionsValid}
           tooltipText={
             !areAllOptionsValid
               ? intl.formatMessage({

--- a/src/pages/fieldManagement/settings/saveField/OptionEditor.jsx
+++ b/src/pages/fieldManagement/settings/saveField/OptionEditor.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
+
 import FormControl from '@material-ui/core/FormControl';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -18,9 +19,12 @@ export default function OptionEditor({
   onChange,
   ...rest
 }) {
+  const intl = useIntl();
   const options = value || [];
   const displayedOptions =
-    options.length > 0 ? options : [{ label: '', value: '' }];
+    options.length > 0
+      ? options
+      : [{ label: '', value: '', created: new Date() }];
 
   return (
     <StandardDialog
@@ -31,7 +35,9 @@ export default function OptionEditor({
       <DialogContent style={{ minWidth: 200 }}>
         {displayedOptions.map((option, optionIndex) => {
           const otherOptions = options.filter(
-            o => o.value !== option.value,
+            o =>
+              o?.created !== option?.created ||
+              o.value !== option?.value,
           );
           const showDeleteButton = displayedOptions.length !== 1;
           return (
@@ -41,7 +47,7 @@ export default function OptionEditor({
                 flexDirection: 'column',
                 marginBottom: 12,
               }}
-              key={option.value}
+              key={option?.created || option?.value}
             >
               <div style={{ display: 'flex', alignItems: 'center' }}>
                 <Text variant="subtitle2" id="OPTION" />
@@ -97,6 +103,7 @@ export default function OptionEditor({
               {
                 label: '',
                 value: '',
+                created: Date.now(),
               },
             ]);
           }}
@@ -110,7 +117,24 @@ export default function OptionEditor({
         </Button>
       </DialogContent>
       <DialogActions style={{ padding: '0px 24px 24px 24px' }}>
-        <Button display="primary" onClick={onSubmit}>
+        <Button
+          disabled={
+            displayedOptions.filter(
+              option => !option?.value || !option?.label,
+            ).length > 0
+          }
+          tooltiptext={
+            displayedOptions.filter(
+              option => !option?.value || !option?.label,
+            ).length > 0
+              ? intl.formatMessage({
+                  id: 'UNFINISHED_OPTIONS',
+                })
+              : ''
+          }
+          display="primary"
+          onClick={onSubmit}
+        >
           <FormattedMessage id="FINISH" />
         </Button>
       </DialogActions>

--- a/src/pages/fieldManagement/settings/saveField/OptionEditor.jsx
+++ b/src/pages/fieldManagement/settings/saveField/OptionEditor.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useIntl, FormattedMessage } from 'react-intl';
+import { map, filter, uniq } from 'lodash-es';
 
 import FormControl from '@material-ui/core/FormControl';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -22,9 +23,19 @@ export default function OptionEditor({
   const intl = useIntl();
   const options = value || [];
   const displayedOptions =
-    options.length > 0
-      ? options
-      : [{ label: '', value: '', created: new Date() }];
+    options.length > 0 ? options : [{ label: '', value: '' }];
+
+  const areAllOptionsNonEmpty =
+    filter(
+      displayedOptions,
+      option => !option?.value || !option?.label,
+    ).length === 0;
+  const areAllValuesUnique =
+    uniq(map(displayedOptions, option => option?.value)).length ===
+    displayedOptions.length;
+
+  const areAllOptionsValid =
+    areAllOptionsNonEmpty && areAllValuesUnique;
 
   return (
     <StandardDialog
@@ -33,68 +44,72 @@ export default function OptionEditor({
       titleId="OPTION_EDITOR"
     >
       <DialogContent style={{ minWidth: 200 }}>
-        {displayedOptions.map((option, optionIndex) => {
-          const otherOptions = options.filter(
-            o =>
-              o?.created !== option?.created ||
-              o.value !== option?.value,
-          );
-          const showDeleteButton = displayedOptions.length !== 1;
-          return (
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                marginBottom: 12,
-              }}
-              key={option?.created || option?.value}
-            >
-              <div style={{ display: 'flex', alignItems: 'center' }}>
-                <Text variant="subtitle2" id="OPTION" />
-                {showDeleteButton && (
-                  <DeleteButton
-                    onClick={() => onChange(otherOptions)}
-                  />
-                )}
-              </div>
+        {map(
+          displayedOptions,
+          (option, optionIndex) => {
+            const otherOptions = options.filter(
+              (o, oIdx) => oIdx !== optionIndex,
+            );
+            const showDeleteButton = displayedOptions.length !== 1;
+            return (
               <div
-                style={{ display: 'flex', alignItems: 'flex-end' }}
-                {...rest}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  marginBottom: 12,
+                }}
+                key={optionIndex}
               >
-                <FormControl style={{ marginRight: 12 }}>
-                  <TextInput
-                    onChange={label => {
-                      const newOptions = [...options];
-                      newOptions[optionIndex] = {
-                        ...option,
-                        label,
-                      };
-                      onChange(newOptions);
-                    }}
-                    width={200}
-                    schema={{ labelId: 'OPTION_LABEL' }}
-                    value={option.label}
-                  />
-                </FormControl>
-                <FormControl style={{ marginLeft: 12 }}>
-                  <TextInput
-                    onChange={newValue => {
-                      const newOptions = [...options];
-                      newOptions[optionIndex] = {
-                        ...option,
-                        value: newValue,
-                      };
-                      onChange(newOptions);
-                    }}
-                    width={200}
-                    schema={{ labelId: 'OPTION_VALUE' }}
-                    value={option.value}
-                  />
-                </FormControl>
+                <div
+                  style={{ display: 'flex', alignItems: 'center' }}
+                >
+                  <Text variant="subtitle2" id="OPTION" />
+                  {showDeleteButton && (
+                    <DeleteButton
+                      onClick={() => onChange(otherOptions)}
+                    />
+                  )}
+                </div>
+                <div
+                  style={{ display: 'flex', alignItems: 'flex-end' }}
+                  {...rest}
+                >
+                  <FormControl style={{ marginRight: 12 }}>
+                    <TextInput
+                      onChange={label => {
+                        const newOptions = [...options];
+                        newOptions[optionIndex] = {
+                          ...option,
+                          label,
+                        };
+                        onChange(newOptions);
+                      }}
+                      width={200}
+                      schema={{ labelId: 'OPTION_LABEL' }}
+                      value={option.label}
+                    />
+                  </FormControl>
+                  <FormControl style={{ marginLeft: 12 }}>
+                    <TextInput
+                      onChange={newValue => {
+                        const newOptions = [...options];
+                        newOptions[optionIndex] = {
+                          ...option,
+                          value: newValue,
+                        };
+                        onChange(newOptions);
+                      }}
+                      width={200}
+                      schema={{ labelId: 'OPTION_VALUE' }}
+                      value={option.value}
+                    />
+                  </FormControl>
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          },
+          [],
+        )}
         <Button
           style={{ marginTop: 16 }}
           onClick={() => {
@@ -103,7 +118,6 @@ export default function OptionEditor({
               {
                 label: '',
                 value: '',
-                created: Date.now(),
               },
             ]);
           }}
@@ -118,20 +132,14 @@ export default function OptionEditor({
       </DialogContent>
       <DialogActions style={{ padding: '0px 24px 24px 24px' }}>
         <Button
-          disabled={
-            displayedOptions.filter(
-              option => !option?.value || !option?.label,
-            ).length > 0
-          }
+          disabled={!areAllOptionsValid}
           showTooltip
           tooltipText={
-            displayedOptions.filter(
-              option => !option?.value || !option?.label,
-            ).length > 0
+            !areAllOptionsValid
               ? intl.formatMessage({
                   id: 'UNFINISHED_OPTIONS',
                 })
-              : ''
+              : undefined
           }
           display="primary"
           onClick={onSubmit}

--- a/src/pages/fieldManagement/settings/saveField/OptionEditor.jsx
+++ b/src/pages/fieldManagement/settings/saveField/OptionEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useIntl, FormattedMessage } from 'react-intl';
-import { map, filter, uniq } from 'lodash-es';
+import { map, some, uniqBy } from 'lodash-es';
 
 import FormControl from '@material-ui/core/FormControl';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -25,13 +25,13 @@ export default function OptionEditor({
   const displayedOptions =
     options.length > 0 ? options : [{ label: '', value: '' }];
 
-  const areAllOptionsNonEmpty =
-    filter(
-      displayedOptions,
-      option => !option?.value || !option?.label,
-    ).length === 0;
+  const areAllOptionsNonEmpty = !some(
+    displayedOptions,
+    option => !option?.value || !option?.label,
+  );
+
   const areAllValuesUnique =
-    uniq(map(displayedOptions, option => option?.value)).length ===
+    uniqBy(displayedOptions, option => option?.value).length ===
     displayedOptions.length;
 
   const areAllOptionsValid =
@@ -44,72 +44,66 @@ export default function OptionEditor({
       titleId="OPTION_EDITOR"
     >
       <DialogContent style={{ minWidth: 200 }}>
-        {map(
-          displayedOptions,
-          (option, optionIndex) => {
-            const otherOptions = options.filter(
-              (o, oIdx) => oIdx !== optionIndex,
-            );
-            const showDeleteButton = displayedOptions.length !== 1;
-            return (
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  marginBottom: 12,
-                }}
-                key={optionIndex}
-              >
-                <div
-                  style={{ display: 'flex', alignItems: 'center' }}
-                >
-                  <Text variant="subtitle2" id="OPTION" />
-                  {showDeleteButton && (
-                    <DeleteButton
-                      onClick={() => onChange(otherOptions)}
-                    />
-                  )}
-                </div>
-                <div
-                  style={{ display: 'flex', alignItems: 'flex-end' }}
-                  {...rest}
-                >
-                  <FormControl style={{ marginRight: 12 }}>
-                    <TextInput
-                      onChange={label => {
-                        const newOptions = [...options];
-                        newOptions[optionIndex] = {
-                          ...option,
-                          label,
-                        };
-                        onChange(newOptions);
-                      }}
-                      width={200}
-                      schema={{ labelId: 'OPTION_LABEL' }}
-                      value={option.label}
-                    />
-                  </FormControl>
-                  <FormControl style={{ marginLeft: 12 }}>
-                    <TextInput
-                      onChange={newValue => {
-                        const newOptions = [...options];
-                        newOptions[optionIndex] = {
-                          ...option,
-                          value: newValue,
-                        };
-                        onChange(newOptions);
-                      }}
-                      width={200}
-                      schema={{ labelId: 'OPTION_VALUE' }}
-                      value={option.value}
-                    />
-                  </FormControl>
-                </div>
+        {map(displayedOptions, (option, optionIndex) => {
+          const otherOptions = options.filter(
+            (o, oIdx) => oIdx !== optionIndex,
+          );
+          const showDeleteButton = displayedOptions.length !== 1;
+          return (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                marginBottom: 12,
+              }}
+              key={optionIndex}
+            >
+              <div style={{ display: 'flex', alignItems: 'center' }}>
+                <Text variant="subtitle2" id="OPTION" />
+                {showDeleteButton && (
+                  <DeleteButton
+                    onClick={() => onChange(otherOptions)}
+                  />
+                )}
               </div>
-            );
-          },
-          [],
-        )}
+              <div
+                style={{ display: 'flex', alignItems: 'flex-end' }}
+                {...rest}
+              >
+                <FormControl style={{ marginRight: 12 }}>
+                  <TextInput
+                    onChange={label => {
+                      const newOptions = [...options];
+                      newOptions[optionIndex] = {
+                        ...option,
+                        label,
+                      };
+                      onChange(newOptions);
+                    }}
+                    width={200}
+                    schema={{ labelId: 'OPTION_LABEL' }}
+                    value={option.label}
+                  />
+                </FormControl>
+                <FormControl style={{ marginLeft: 12 }}>
+                  <TextInput
+                    onChange={newValue => {
+                      const newOptions = [...options];
+                      newOptions[optionIndex] = {
+                        ...option,
+                        value: newValue,
+                      };
+                      onChange(newOptions);
+                    }}
+                    width={200}
+                    schema={{ labelId: 'OPTION_VALUE' }}
+                    value={option.value}
+                  />
+                </FormControl>
+              </div>
+            </div>
+          );
+        })}
         <Button
           style={{ marginTop: 16 }}
           onClick={() => {

--- a/src/pages/fieldManagement/settings/saveField/OptionEditor.jsx
+++ b/src/pages/fieldManagement/settings/saveField/OptionEditor.jsx
@@ -123,7 +123,8 @@ export default function OptionEditor({
               option => !option?.value || !option?.label,
             ).length > 0
           }
-          tooltiptext={
+          showTooltip
+          tooltipText={
             displayedOptions.filter(
               option => !option?.value || !option?.label,
             ).length > 0

--- a/src/pages/fieldManagement/settings/saveField/OptionEditor.jsx
+++ b/src/pages/fieldManagement/settings/saveField/OptionEditor.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { v4 as uuid } from 'uuid';
 import FormControl from '@material-ui/core/FormControl';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -21,7 +20,7 @@ export default function OptionEditor({
 }) {
   const options = value || [];
   const displayedOptions =
-    options.length > 0 ? options : [{ label: '', value: '', id: 6 }];
+    options.length > 0 ? options : [{ label: '', value: '' }];
 
   return (
     <StandardDialog
@@ -32,7 +31,7 @@ export default function OptionEditor({
       <DialogContent style={{ minWidth: 200 }}>
         {displayedOptions.map((option, optionIndex) => {
           const otherOptions = options.filter(
-            o => o.id !== option.id,
+            o => o.value !== option.value,
           );
           const showDeleteButton = displayedOptions.length !== 1;
           return (
@@ -42,7 +41,7 @@ export default function OptionEditor({
                 flexDirection: 'column',
                 marginBottom: 12,
               }}
-              key={option.id}
+              key={option.value}
             >
               <div style={{ display: 'flex', alignItems: 'center' }}>
                 <Text variant="subtitle2" id="OPTION" />
@@ -98,7 +97,6 @@ export default function OptionEditor({
               {
                 label: '',
                 value: '',
-                id: uuid(),
               },
             ]);
           }}


### PR DESCRIPTION
Pull request checklist:
 - [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
 - [ ] All text is internationalized 
     - N/A
 - [x] There are no linter errors
 - [ ] New features support all states (loading, error, etc) 
     - N/A

- [ ] Thanks for keeping it clean! Feel free to merge your own pull request after it has been approved - just use the "squash & merge" option.

This PR removes the unneccesary id attribute from custom filed options. This brings newly-created custom field options in line with the current behavior of migrated custom fields. 
The removal of id here does not seem to affect the metadata cards for sightings or encounters.

It was decided that, because the end users will be exporting, bulk importing, and otherwise using these custom field options, they should be in control of what both the labels and values are (provided that these are unique - see DEX-1270 for that issue).

# QA notes:

## Old behavior when an admin tried to remove any multi-select custom field option:

Before deleting "Standing":
<img width="1840" alt="Screen Shot 2022-06-30 at 12 37 44 PM" src="https://user-images.githubusercontent.com/2775448/176763096-46393cf3-a749-450a-8bca-cee438ce21d9.png">

After deleting "Standing":
<img width="1840" alt="Screen Shot 2022-06-30 at 12 34 14 PM" src="https://user-images.githubusercontent.com/2775448/176762351-341a10ce-956e-4be2-8f49-6492d6160ea5.png">
(i.e., they would all be removed)


## New behavior after this PR gets merged:

Before deleting "Standing":
<img width="1840" alt="Screen Shot 2022-06-30 at 12 37 44 PM" src="https://user-images.githubusercontent.com/2775448/176762972-f27f1def-462c-4b2a-8002-0eec9b161f1f.png">

After deleting "Standing":
<img width="1840" alt="Screen Shot 2022-06-30 at 12 37 52 PM" src="https://user-images.githubusercontent.com/2775448/176763039-b53a81ee-4c57-4ca7-86fa-9908a26fbc01.png">


Other things to confirm:
- [ ] Creating a new multi-select custom field and creating options works and persists without error
- [ ] Editing (add/removing) options from the above works and persists without error
- [ ] Creating a new single-select (a.k.a dropdown) custom field and creating options works and persists without error
- [ ] Editing (add/removing) options from the above works and persists without error
- [ ] Confirm that metadata cards for sightings or encounters on some old sightings page are not wonky as a result of this.


