### PR TITLE
dex 1197 - clean up useServerStatus

### DIFF
--- a/src/constants/queryKeys.js
+++ b/src/constants/queryKeys.js
@@ -12,6 +12,7 @@ export default {
   unreadNotifications: 'unreadNotifications',
   twitterBotTestResults: 'twitterBotTestResults',
   publicData: 'publicData',
+  sageJobs: ['sage', 'jobs'],
 };
 
 export function getAuditLogQueryKey(guid) {

--- a/src/models/sage/useSageJobs.js
+++ b/src/models/sage/useSageJobs.js
@@ -1,0 +1,13 @@
+import useFetch from '../../hooks/useFetch';
+import queryKeys from '../../constants/queryKeys';
+
+export default function useSageJobs() {
+  return useFetch({
+    queryKey: queryKeys.sageJobs,
+    url: '/sage/jobs',
+    queryOptions: {
+      staleTime: 0,
+      cacheTime: 5 * 60 * 1000, // 5 minutes
+    },
+  });
+}

--- a/src/pages/serverStatus/ServerStatus.jsx
+++ b/src/pages/serverStatus/ServerStatus.jsx
@@ -11,7 +11,7 @@ import { useTheme } from '@material-ui/core/styles';
 import version from '../../constants/version';
 import useGetSiteInfo from '../../models/site/useGetSiteInfo';
 import useDocumentTitle from '../../hooks/useDocumentTitle';
-import useServerStatus from '../../models/server/useServerStatus';
+import useSageJobs from '../../models/sage/useSageJobs';
 import MainColumn from '../../components/MainColumn';
 import Text from '../../components/Text';
 import SettingsBreadcrumbs from '../../components/SettingsBreadcrumbs';
@@ -19,6 +19,7 @@ import SummaryCard from './components/SummaryCard';
 import LegendItem from './components/LegendItem';
 import WaffleSquare from './components/WaffleSquare';
 import { getElapsedTimeInWords } from '../../utils/formatters';
+import { getSageJobsStatistics } from '../../utils/sageUtils';
 
 const skeletonHeight = `${16 / 0.6}px`;
 
@@ -66,8 +67,9 @@ export default function ServerStatus() {
 
   useDocumentTitle('SERVER_STATUS');
 
-  const [results, error, isFetched] = useServerStatus();
-  const { lastHour, twoWeeks, byStatus } = results;
+  const { data, error, isFetched } = useSageJobs();
+  const { lastHour, twoWeeks, byStatus } =
+    getSageJobsStatistics(data);
 
   const jobsProcessedInLastHour = get(lastHour, 'jobsProcessed', 0);
   const jobsProcessedInTwoWeeks = get(twoWeeks, 'jobsProcessed', 0);

--- a/src/pages/serverStatus/ServerStatus.jsx
+++ b/src/pages/serverStatus/ServerStatus.jsx
@@ -67,7 +67,7 @@ export default function ServerStatus() {
 
   useDocumentTitle('SERVER_STATUS');
 
-  const { data, error, isFetched } = useSageJobs();
+  const { data, error, isLoading } = useSageJobs();
   const { lastHour, twoWeeks, byStatus } =
     getSageJobsStatistics(data);
 
@@ -189,7 +189,7 @@ export default function ServerStatus() {
                   <SummaryCard
                     xs={12}
                     sm={4}
-                    loading={!isFetched}
+                    loading={isLoading}
                     title={
                       <FormattedMessage id="SERVER_SUMMARY_TURNAROUND_TIME" />
                     }
@@ -213,7 +213,7 @@ export default function ServerStatus() {
                   <SummaryCard
                     xs={12}
                     sm={4}
-                    loading={!isFetched}
+                    loading={isLoading}
                     title={
                       <FormattedMessage id="SERVER_SUMMARY_RUN_TIME" />
                     }
@@ -237,7 +237,7 @@ export default function ServerStatus() {
                   <SummaryCard
                     xs={12}
                     sm={4}
-                    loading={!isFetched}
+                    loading={isLoading}
                     title={
                       <FormattedMessage id="SERVER_SUMMARY_JOBS_PROCESSED" />
                     }
@@ -267,7 +267,7 @@ export default function ServerStatus() {
               <SummaryCard
                 xs={12}
                 sm={4}
-                loading={!isFetched}
+                loading={isLoading}
                 title={
                   <FormattedMessage id="SERVER_SUMMARY_TURNAROUND_TIME" />
                 }
@@ -291,7 +291,7 @@ export default function ServerStatus() {
               <SummaryCard
                 xs={12}
                 sm={4}
-                loading={!isFetched}
+                loading={isLoading}
                 title={
                   <FormattedMessage id="SERVER_SUMMARY_RUN_TIME" />
                 }
@@ -313,7 +313,7 @@ export default function ServerStatus() {
               <SummaryCard
                 xs={12}
                 sm={4}
-                loading={!isFetched}
+                loading={isLoading}
                 title={
                   <FormattedMessage id="SERVER_SUMMARY_JOBS_IN_QUEUE" />
                 }
@@ -342,7 +342,15 @@ export default function ServerStatus() {
                 )}
               </dl>
             </header>
-            {isFetched ? (
+            {isLoading ? (
+              <>
+                <Skeleton height={skeletonHeight} />
+                <Skeleton height={skeletonHeight} />
+                <Skeleton height={skeletonHeight} />
+                <Skeleton height={skeletonHeight} />
+                <Skeleton height={skeletonHeight} width="60%" />
+              </>
+            ) : (
               <div style={{ padding: 0, margin: -3 }}>
                 {Object.entries(byStatus)
                   .filter(entry => entry[1].length > 0)
@@ -367,14 +375,6 @@ export default function ServerStatus() {
                     </React.Fragment>
                   ))}
               </div>
-            ) : (
-              <>
-                <Skeleton height={skeletonHeight} />
-                <Skeleton height={skeletonHeight} />
-                <Skeleton height={skeletonHeight} />
-                <Skeleton height={skeletonHeight} />
-                <Skeleton height={skeletonHeight} width="60%" />
-              </>
             )}
           </>
         )}


### PR DESCRIPTION
Pull request checklist:
 - [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
 - [x] ~All text is internationalized~ **No new user facing text**
 - [x] There are no linter errors
 - [x] ~New features support all states (loading, error, etc)~ **No new features**

## Pull Request Overview
- Accesses Sage jobs using the houston endpoint exposed in WildMeOrg/houston#717 instead of the hard coded kaiju endpoint.
- Migrates the request for Sage jobs to React Query (DEX-766)
  - Moves the statistics building logic into a util file.
