### PR TITLE
dex 1117 - Replace progress with pipeline_status in Asset Group

### DIFF
--- a/src/pages/assetGroup/AssetGroup.jsx
+++ b/src/pages/assetGroup/AssetGroup.jsx
@@ -26,18 +26,25 @@ import AGSTable from './AGSTable';
 
 const POLLING_INTERVAL = 5000; // 5 seconds
 
+function isProgressSettled(pipelineStatus) {
+  const { skipped, failed, complete } = pipelineStatus || {};
+
+  return skipped || complete || failed;
+}
+
 function deriveRefetchInterval(resultData, query) {
-  const { complete, status } =
-    resultData?.data?.progress_preparation || {};
+  const pipelineStatus = get(
+    resultData,
+    'data.pipeline_status.preparation',
+    {},
+  );
 
-  const error = query.state?.error && { ...query.state.error };
+  const isSettled = isProgressSettled(pipelineStatus);
 
-  const isProgressSettled =
-    complete || ['failed', 'cancelled'].includes(status) || error;
+  const isError = Boolean(query.state?.error);
 
-  const refetchInterval = isProgressSettled
-    ? false
-    : POLLING_INTERVAL;
+  const refetchInterval =
+    isSettled || isError ? false : POLLING_INTERVAL;
 
   return refetchInterval;
 }
@@ -86,15 +93,12 @@ export default function AssetGroup() {
     intl.formatMessage({ id: 'UNNAMED_USER' });
   const creatorUrl = `/users/${sightingCreator?.guid}`;
 
-  const {
-    complete: isPreparationProgressComplete,
-    failed: isPreparationProgressFailed,
-    cancelled: isPreparationProgressCancelled,
-  } = get(data, 'progress_preparation', {});
-  const showPreparationErrorAlert =
-    isPreparationProgressFailed || isPreparationProgressCancelled;
-  const showPreparationInProgressAlert =
-    !showPreparationErrorAlert && !isPreparationProgressComplete;
+  const pipelineStatusPreparation = get(
+    data,
+    'pipeline_status.preparation',
+    {},
+  );
+  const isPreparationFailed = pipelineStatusPreparation.failed;
 
   return (
     <MainColumn fullWidth>
@@ -146,32 +150,33 @@ export default function AssetGroup() {
           </Text>
         )}
       </EntityHeader>
-      {showPreparationErrorAlert && (
+      {isPreparationFailed && (
         <CustomAlert
           titleId="IMAGE_PROCESSING_ERROR"
           descriptionId="IMAGE_PROCESSING_ERROR_MESSAGE"
           severity="error"
         />
       )}
-      {showPreparationInProgressAlert && (
-        <>
-          <LinearProgress
-            style={{
-              borderTopLeftRadius: '4px',
-              borderTopRightRadius: '4px',
-            }}
-          />
-          <CustomAlert
-            titleId="PENDING_IMAGE_PROCESSING"
-            descriptionId="PENDING_IMAGE_PROCESSING_MESSAGE"
-            severity="info"
-            style={{
-              borderTopLeftRadius: '0px',
-              borderTopRightRadius: '0px',
-            }}
-          />
-        </>
-      )}
+      {!isPreparationFailed &&
+        !isProgressSettled(pipelineStatusPreparation) && (
+          <>
+            <LinearProgress
+              style={{
+                borderTopLeftRadius: '4px',
+                borderTopRightRadius: '4px',
+              }}
+            />
+            <CustomAlert
+              titleId="PENDING_IMAGE_PROCESSING"
+              descriptionId="PENDING_IMAGE_PROCESSING_MESSAGE"
+              severity="info"
+              style={{
+                borderTopLeftRadius: '0px',
+                borderTopRightRadius: '0px',
+              }}
+            />
+          </>
+        )}
       <AGSTable
         assetGroupSightings={get(data, 'asset_group_sightings', [])}
       />

--- a/src/pages/assetGroup/AssetGroup.jsx
+++ b/src/pages/assetGroup/AssetGroup.jsx
@@ -100,6 +100,11 @@ export default function AssetGroup() {
   );
   const isPreparationFailed = pipelineStatusPreparation.failed;
 
+  const showPreparationInProgressAlert = !(
+    isPreparationFailed ||
+    isProgressSettled(pipelineStatusPreparation)
+  );
+
   return (
     <MainColumn fullWidth>
       <ConfirmDelete
@@ -157,26 +162,25 @@ export default function AssetGroup() {
           severity="error"
         />
       )}
-      {!isPreparationFailed &&
-        !isProgressSettled(pipelineStatusPreparation) && (
-          <>
-            <LinearProgress
-              style={{
-                borderTopLeftRadius: '4px',
-                borderTopRightRadius: '4px',
-              }}
-            />
-            <CustomAlert
-              titleId="PENDING_IMAGE_PROCESSING"
-              descriptionId="PENDING_IMAGE_PROCESSING_MESSAGE"
-              severity="info"
-              style={{
-                borderTopLeftRadius: '0px',
-                borderTopRightRadius: '0px',
-              }}
-            />
-          </>
-        )}
+      {showPreparationInProgressAlert && (
+        <>
+          <LinearProgress
+            style={{
+              borderTopLeftRadius: 4,
+              borderTopRightRadius: 4,
+            }}
+          />
+          <CustomAlert
+            titleId="PENDING_IMAGE_PROCESSING"
+            descriptionId="PENDING_IMAGE_PROCESSING_MESSAGE"
+            severity="info"
+            style={{
+              borderTopLeftRadius: 0,
+              borderTopRightRadius: 0,
+            }}
+          />
+        </>
+      )}
       <AGSTable
         assetGroupSightings={get(data, 'asset_group_sightings', [])}
       />


### PR DESCRIPTION
Pull request checklist:
 - [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
 - [x] ~All text is internationalized~ **No user facing text**
 - [x] There are no linter errors
 - [x] New features support all states (loading, error, etc)

## Pull Request Overview
- In AssetGroup, determines the preparation status from the Asset Group's `pipeline_status` property instead of its `progress_preparation` property.
- Related to WildmeOrg/houston#744

This is the expected behavior:
| progress status | pipeline status | front end
| --- | --- | ---
| progress doesn't exist | complete | no alert, table displays with asset counts, no data refetch
| created | inProgress | in progress alert, table displays asset counts as "pending", poll API for data
| healthy | inProgress | in progress alert, table displays asset counts as "pending", poll API for data
| completed | complete | no alert, able displays with asset counts, no data refetch
| skipped | skipped | no alert, table displays with asset counts, no refetch
| cancelled | waiting | in progress alert, table displays asset counts as "pending", poll API for data
| failed | failed | error alert, table displays asset counts as "pending", no refetch
