### PR TITLE
dex 1303 - Add Saimma Seal to migrated Wildbooks list

### DIFF
--- a/src/constants/wildbookBySystemGuid.js
+++ b/src/constants/wildbookBySystemGuid.js
@@ -1,5 +1,7 @@
 const wildbookBySystemGuid = {
   'e144fec3-2f47-4195-8025-a8915f9a52a1': 'Wildbook for Zebras',
+  'a052f432-014b-4f07-a21f-9c824977b2a5':
+    'WWF: Norppagalleria Wildbook',
 };
 
 export default wildbookBySystemGuid;


### PR DESCRIPTION
Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x] ~All text is internationalized~ **No user facing text**
- [x] There are no linter errors
- [x] ~New features support all states (loading, error, etc)~ **No new features**

Which JIRA ticket(s) and/or GitHub issues does this PR address?
  - DEX-1303 - Add Saimma Seal to front end's migrated Wildbooks list.

---
## Pull Request Overview
- Adds "WWF: Norppagalleria Wildbook" to the list of Wildbooks by system GUID so that status messages can refer to the Wildbook by name:
<img width="557" alt="migrated-norppagalleria-wildbook" src="https://user-images.githubusercontent.com/50299119/178049287-0f9a334c-1fbb-4464-b236-96af10e59c87.png">

---

**Review Notes**
- You will not be able to see this text locally because your instance of Codex has a different system guid.
- The system guid is a site setting with id `system_guid`
