### PR TITLE
dex 1326 - frozen user settings page

### DIFF
--- a/src/pages/settings/Settings.jsx
+++ b/src/pages/settings/Settings.jsx
@@ -44,8 +44,12 @@ export default function Settings() {
   const [formValues, setFormValues] = useState({});
   useEffect(() => {
     const initialValues = getInitialFormValues(schemas, data);
-    setFormValues({ ...initialValues, ...formValues });
-  }, [formValues, schemas, data]);
+
+    setFormValues(prevFormValues => ({
+      ...initialValues,
+      ...prevFormValues,
+    }));
+  }, [schemas, data]);
 
   const backendValues = useMemo(
     () => getInitialFormValues(schemas, data),


### PR DESCRIPTION
Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x] ~All text is internationalized~ **No new user facing text**
- [x] There are no linter errors
- [x] ~New features support all states (loading, error, etc)~ **No new features**

Which JIRA ticket(s) and/or GitHub issues does this PR address?
- DEX-1326: User Settings page is frozen

-----

## Pull Request Overview

- Prevents the page at `/settings` from freezing because of excessive updates by computing the new form value state from an argument provided when setting the state rather than the `formValues` variable.