### PR TITLE
DEX-1176 add minWidth

### DIFF
--- a/src/components/BannerLogo.jsx
+++ b/src/components/BannerLogo.jsx
@@ -63,6 +63,7 @@ export default function BannerLogo({
                 ? theme.palette.common.black
                 : theme.palette.common.white,
               margin: '0 12px 0 8px',
+              minWidth: 200,
             }}
           >
             {siteName}

--- a/src/components/BannerLogo.jsx
+++ b/src/components/BannerLogo.jsx
@@ -36,16 +36,19 @@ export default function BannerLogo({
     <Container
       href={href}
       onClick={onClick}
+      style={{ display: 'flex' }}
       {...containerProps}
       {...rest}
     >
       <div style={{ display: 'flex', alignItems: 'center' }}>
         {logo ? (
-          <img
-            alt={`Logo for ${siteName}`}
-            src={logo}
-            style={{ height: 52, flexShrink: 0 }}
-          />
+          <div>
+            <img
+              alt={`Logo for ${siteName}`}
+              src={logo}
+              style={{ height: 52, flexShrink: 0 }}
+            />
+          </div>
         ) : (
           <InstanceLogo
             style={{
@@ -63,7 +66,6 @@ export default function BannerLogo({
                 ? theme.palette.common.black
                 : theme.palette.common.white,
               margin: '0 12px 0 8px',
-              minWidth: 200,
             }}
           >
             {siteName}

--- a/src/components/BannerLogo.jsx
+++ b/src/components/BannerLogo.jsx
@@ -36,7 +36,6 @@ export default function BannerLogo({
     <Container
       href={href}
       onClick={onClick}
-      style={{ display: 'flex' }}
       {...containerProps}
       {...rest}
     >


### PR DESCRIPTION
Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [ ] All text is internationalized
    - N/A
- [x] There are no linter errors
- [ ] New features support all states (loading, error, etc)
    - N/A

Which JIRA ticket(s) and/or GitHub issues does this PR address?
DEX-1176 (the issue was the the header title in zebra codex was wrapping in small screen sizes).

Thanks for keeping it clean! Feel free to merge your own pull request after it has been approved - just use the "squash & merge" option.

I'm not certain of the best way to handle very long codex names, but adding a min-width of a reasonable length seemed to fix the issue at hand. Ignore not-quite-suitable branch name.

<img width="1440" alt="Screen Shot 2022-07-26 at 8 58 23 AM" src="https://user-images.githubusercontent.com/2775448/181054492-7b34bc7b-81dc-44ef-9265-30395b4c335a.png">

