### PR TITLE
dex 1371 - remove data manager role

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -15,7 +15,6 @@
   "STAGE": "Stage",
   "NO_PENDING_PUBLIC_SIGHTINGS": "There are no pending public sightings",
   "DATA_UNAVAILABLE": "Data unavailable",
-  "DATA_MANAGER": "Data Manager",
   "ANNOTATION_CLASS": "Annotation class",
   "INDIVIDUAL_METADATA": "Individual profile",
   "COMMIT": "Commit",

--- a/src/components/AuthenticatedAppHeader/ActionsPane.jsx
+++ b/src/components/AuthenticatedAppHeader/ActionsPane.jsx
@@ -27,8 +27,7 @@ const actions = [
   {
     id: 'pending-citizen-science-sightings',
     href: '/pending-citizen-science-sightings',
-    permissionsTest: userData =>
-      userData?.is_admin || userData?.is_data_manager,
+    permissionsTest: userData => userData?.is_admin,
     messageId: 'PENDING_CITIZEN_SCIENCE_SIGHTINGS',
     icon: PublicIcon,
   },

--- a/src/pages/userManagement/constants/roleSchema.js
+++ b/src/pages/userManagement/constants/roleSchema.js
@@ -12,10 +12,6 @@ export default [
     titleId: 'USER_MANAGER',
   },
   {
-    id: 'is_data_manager',
-    titleId: 'DATA_MANAGER',
-  },
-  {
     id: 'is_exporter',
     titleId: 'EXPORTER',
   },


### PR DESCRIPTION
Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x] ~All text is internationalized~ **No new text**
- [x] There are no linter errors
- [x] ~New features support all states (loading, error, etc)~ **There are no new features**

Which JIRA ticket(s) and/or GitHub issues does this PR address?
- DEX-1371: Codex FE remove usage of Data manager role

## Pull Request Overview

- Removes all instances where the "data manager" role is used.