### PR TITLE
dex 1343 - clear collaboration failure after success

### DIFF
--- a/src/pages/collaborations/collaborationManagementForm.jsx
+++ b/src/pages/collaborations/collaborationManagementForm.jsx
@@ -71,7 +71,7 @@ export default function CollaborationManagementForm({
             return unnamedUserLabel;
           }}
           getOptionSelected={(option, val) =>
-            option.id ? option.id === val : false
+            option.guid ? option.guid === val.guid : false
           }
           renderInput={params => (
             <TextField
@@ -115,7 +115,7 @@ export default function CollaborationManagementForm({
             return unnamedUserLabel;
           }}
           getOptionSelected={(option, val) =>
-            option.id ? option.id === val : false
+            option.guid ? option.guid === val.guid : false
           }
           renderInput={params => (
             <TextField

--- a/src/pages/collaborations/collaborationManagementForm.jsx
+++ b/src/pages/collaborations/collaborationManagementForm.jsx
@@ -176,7 +176,6 @@ export default function CollaborationManagementForm({
       </div>
       {success && (
         <CustomAlert
-          style={{ margin: '0px 24px 20px 24px' }}
           titleId="COLLABORATION_CREATED"
           severity="success"
           onClose={clearSuccess}
@@ -184,16 +183,14 @@ export default function CollaborationManagementForm({
       )}
       {error && (
         <CustomAlert
-          style={{ margin: '20px 0', width: '100%' }}
           severity="error"
           titleId="SERVER_ERROR"
+          description={error}
           onClose={() => {
             clearEstablishCollaborationError();
             setFormError(null);
           }}
-        >
-          {error}
-        </CustomAlert>
+        />
       )}
     </div>
   );

--- a/src/pages/collaborations/collaborationManagementForm.jsx
+++ b/src/pages/collaborations/collaborationManagementForm.jsx
@@ -17,7 +17,6 @@ export default function CollaborationManagementForm({
   existingCollaborations,
 }) {
   const intl = useIntl();
-  const [shouldDisplay, setShouldDisplay] = useState(false);
   const [user1, setUser1] = useState(null);
   const [user2, setUser2] = useState(null);
   const [formError, setFormError] = useState(null);
@@ -25,7 +24,9 @@ export default function CollaborationManagementForm({
     mutate: establishCollaboration,
     loading,
     error: establishCollaborationError,
+    clearError: clearEstablishCollaborationError,
     success,
+    clearSuccess,
   } = useEstablishCollaborationAsUserManager();
 
   const error = establishCollaborationError || formError;
@@ -136,6 +137,10 @@ export default function CollaborationManagementForm({
           loading={loading}
           id="CREATE_COLLABORATION"
           onClick={async () => {
+            clearSuccess();
+            clearEstablishCollaborationError();
+            setFormError(null);
+
             if (
               mutuallyRevokedCollabExists(
                 existingCollaborations,
@@ -166,27 +171,25 @@ export default function CollaborationManagementForm({
                 }),
               );
             }
-            setShouldDisplay(true);
           }}
         />
       </div>
-      {success && shouldDisplay && (
+      {success && (
         <CustomAlert
           style={{ margin: '0px 24px 20px 24px' }}
           titleId="COLLABORATION_CREATED"
           severity="success"
-          onClose={() => {
-            setShouldDisplay(false);
-          }}
+          onClose={clearSuccess}
         />
       )}
-      {error && shouldDisplay && (
+      {error && (
         <CustomAlert
           style={{ margin: '20px 0', width: '100%' }}
           severity="error"
           titleId="SERVER_ERROR"
           onClose={() => {
-            setShouldDisplay(false);
+            clearEstablishCollaborationError();
+            setFormError(null);
           }}
         >
           {error}


### PR DESCRIPTION
Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x] All text is internationalized
  - The error description is not internationalized, but that is beyond the scope of this checklist 
- [x] There are no linter errors
- [x] ~New features support all states (loading, error, etc)~ **No new features**

Which JIRA ticket(s) and/or GitHub issues does this PR address?
  - DEX-1343 - Failed collaboration create does not get cleared on next success
  - It also makes a two additional changes in the same file that are not in a JIRA ticket or GitHub issue.

## Pull Request Overview

- Clears the POST request's error and success state as well as the form's error state when a new form submission is processed. Also clears the success state when the success alert is dismissed and the error states when the error alert is dismissed.
- Changes the error alert to use the description prop instead of passing the error string as a child.
- Updates both alerts so that they have the same styles.

| previously | now |
| --- | --- |
| <img width="865" alt="previous-error-and-success" src="https://user-images.githubusercontent.com/50299119/184725621-8c7d8085-f8aa-426a-bf41-d150693d0ec1.png"> | <img width="865" alt="new-error-and-success" src="https://user-images.githubusercontent.com/50299119/184725664-8d40c930-ced6-4525-944d-41c1fcd226c2.png"> |
<img width="871" alt="new-error" src="https://user-images.githubusercontent.com/50299119/184725717-4898a1c2-957f-4e25-8e32-be21076181d2.png">
<img width="871" alt="new-success" src="https://user-images.githubusercontent.com/50299119/184725724-ffd2b090-0cbf-4443-ba2f-6d9403ed06f2.png">


- Updates the `getOptionSelected` logic for each `Autocomplete` component, which resolves this warning
```
useAutocomplete.js:249 Material-UI: The value provided to Autocomplete is invalid.
None of the options match with `// provided value`.
You can use the `getOptionSelected` prop to customize the equality test.
```