### PR TITLE
dex 1017 - individual photo gallery - fix copy

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1188,7 +1188,7 @@
   "INDIVIDUAL_GALLERY_SEE_ALL": "See all",
   "INDIVIDUAL_GALLERY_TITLE": "{name}'s gallery",
   "INDIVIDUAL_GALLERY_IMAGE_ALT": "{annotationCount} {annotationCount, plural, one {annotation} other {annotations}} with {assetClassCount, plural, one {class} other {classes}} {assetClassesList}",
-  "INDIVIDUAL_GALLERY_UNABLE_TO_DISPLAY_ANNOTATIONS": "We are currently unable to show annotations for uploaded images with either a width or a height exceeding 4,096 pixels.",
+  "INDIVIDUAL_GALLERY_UNABLE_TO_DISPLAY_ANNOTATIONS": "We are currently unable to show annotations for uploaded images with either a width or a height of 4,096 pixels or more.",
   "INDIVIDUAL_BACK_TO_PROFILE": "Return to {name}'s profile",
   "ERROR_FETCHING_IMAGE": "Error fetching image"
 }


### PR DESCRIPTION
Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x] All text is internationalized
- [x] ~There are no linter errors~ **N/A: only en.json was changed**
- [x] ~New features support all states (loading, error, etc)~ **No new features**

Which JIRA ticket(s) and/or GitHub issues does this PR address?
  - DEX-1017 - Individual photo gallery

## Pull Request Overview

- Changes the copy for the individual image gallery alert to include images with a raw width or height of 4,096 px in the images that cannot currently display annotations.
