### PR TITLE
Fix page error when no notification message

### DIFF
--- a/src/pages/notifications/Notifications.jsx
+++ b/src/pages/notifications/Notifications.jsx
@@ -100,58 +100,59 @@ export default function Notifications() {
                 const createdDate = notification?.created;
                 const timeSince =
                   calculatePrettyTimeElapsedSince(createdDate);
-                const notificationText = (
-                  <Text
-                    key={notification?.guid}
-                    style={{
-                      color: read
-                        ? theme.palette.text.secondary
-                        : theme.palette.text.primary,
-                    }}
-                    variant="body2"
-                  >
-                    {intl.formatMessage(
-                      {
-                        id: currentNotificationSchema?.notificationMessage,
-                      },
-                      {
-                        userName: (
-                          <span>
-                            <Link
-                              newTab
-                              href={`/users/${userNameGuid}`}
-                            >
-                              {userName}
-                            </Link>
-                          </span>
-                        ),
-                        user1Name,
-                        user2Name,
-                        yourIndividualName: (
-                          <span>
-                            <Link
-                              newTab
-                              href={`/individuals/${yourIndividualGuid}`}
-                            >
-                              {yourIndName}
-                            </Link>
-                          </span>
-                        ),
-                        theirIndividualName: (
-                          <span>
-                            <Link
-                              newTab
-                              href={`/individuals/${theirIndividualGuid}`}
-                            >
-                              {theirIndividualName}
-                            </Link>
-                          </span>
-                        ),
-                        formattedDeadline,
-                      },
-                    )}
-                  </Text>
-                );
+                const notificationText =
+                  currentNotificationSchema?.notificationMessage ? (
+                    <Text
+                      key={notification?.guid}
+                      style={{
+                        color: read
+                          ? theme.palette.text.secondary
+                          : theme.palette.text.primary,
+                      }}
+                      variant="body2"
+                    >
+                      {intl.formatMessage(
+                        {
+                          id: currentNotificationSchema.notificationMessage,
+                        },
+                        {
+                          userName: (
+                            <span>
+                              <Link
+                                newTab
+                                href={`/users/${userNameGuid}`}
+                              >
+                                {userName}
+                              </Link>
+                            </span>
+                          ),
+                          user1Name,
+                          user2Name,
+                          yourIndividualName: (
+                            <span>
+                              <Link
+                                newTab
+                                href={`/individuals/${yourIndividualGuid}`}
+                              >
+                                {yourIndName}
+                              </Link>
+                            </span>
+                          ),
+                          theirIndividualName: (
+                            <span>
+                              <Link
+                                newTab
+                                href={`/individuals/${theirIndividualGuid}`}
+                              >
+                                {theirIndividualName}
+                              </Link>
+                            </span>
+                          ),
+                          formattedDeadline,
+                        },
+                      )}
+                    </Text>
+                  ) : null;
                 const howLongAgoText = (
                   <Text
                     style={{


### PR DESCRIPTION
Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x] All text is internationalized
- [x] There are no linter errors
- [x] ~New features support all states (loading, error, etc)~ **No new features**

Which JIRA ticket(s) and/or GitHub issues does this PR address?
  - None. The bug became observable because of WildMeOrg/houston#795 which introduces new notification message types.

---

## Pull Request Overview

- On the notifications page, returns `null` instead of formatted text if there is no notification message. This prevents react-intl from throwing an uncaught error when `undefined` is passed to `id`
