### PR TITLE
dex-1401 - incorrect sighting metadata payload

### DIFF
--- a/src/components/fields/edit/LatLongEditor.jsx
+++ b/src/components/fields/edit/LatLongEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useReducer } from 'react';
 import { useIntl } from 'react-intl';
 import { get } from 'lodash-es';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -15,14 +15,71 @@ function getNumberString(n) {
   return n ? n.toString() : '';
 }
 
-function deriveGpsStringsFromValue(value) {
-  const currentLatitude = get(value, '0', null);
-  const currentLongitude = get(value, '1', null);
-
+function calculateInitialState(coordinates) {
   return {
-    latitudeString: getNumberString(currentLatitude),
-    longitudeString: getNumberString(currentLongitude),
+    latitude: getNumberString(get(coordinates, '0', '')),
+    longitude: getNumberString(get(coordinates, '1', '')),
+    mapCoordinates: null,
+    setterType: 'external',
   };
+}
+
+function reducer(state, action) {
+  switch (action.type) {
+    case 'input-latitude':
+      return {
+        ...state,
+        latitude: action.payload,
+        setterType: 'internal',
+      };
+    case 'input-longitude':
+      return {
+        ...state,
+        longitude: action.payload,
+        setterType: 'internal',
+      };
+    case 'select-map-coordinates':
+      return { ...state, mapCoordinates: action.payload };
+    case 'confirm-map-coordinates':
+      return {
+        ...state,
+        latitude: getNumberString(state.mapCoordinates?.[0]),
+        longitude: getNumberString(state.mapCoordinates?.[1]),
+        mapCoordinates: null,
+        setterType: 'internal',
+      };
+    case 'update-coordinates-externally': {
+      const latitudeString = getNumberString(
+        get(action.payload, '0', ''),
+      );
+      const longitudeString = getNumberString(
+        get(action.payload, '1', ''),
+      );
+
+      if (
+        latitudeString === state.latitude &&
+        longitudeString === state.longitude
+      ) {
+        // The external update was likely caused as a result of this
+        // component's onChange, so bail out of the dispatch by
+        // returning the same state.
+        return state;
+      }
+
+      return {
+        ...state,
+        latitude: latitudeString,
+        longitude: longitudeString,
+        setterType: 'external',
+      };
+    }
+    default:
+      // eslint-disable-next-line no-console
+      console.error(
+        `unsupported action type, ${action.type}, provided to reducer`,
+      );
+      return state;
+  }
 }
 
 export default function LatLongEditor({
@@ -37,34 +94,41 @@ export default function LatLongEditor({
   const description = useDescription(schema);
 
   const [modalOpen, setModalOpen] = useState(false);
-  const [mapLatLng, setMapLatLng] = useState(null);
-  const [savedMapLatLng, setSavedMapLatLng] = useState(null);
+
+  const [state, dispatch] = useReducer(
+    reducer,
+    value,
+    calculateInitialState,
+  );
 
   const {
-    latitudeString: initialLatitudeString,
-    longitudeString: initialLongitudeString,
-  } = useMemo(() => deriveGpsStringsFromValue(value));
-
-  const [currentLatitudeString, setCurrentLatitudeString] = useState(
-    initialLatitudeString,
-  );
-  const [currentLongitudeString, setCurrentLongitudeString] =
-    useState(initialLongitudeString);
+    longitude: longitudeString,
+    latitude: latitudeString,
+    setterType,
+  } = state;
 
   useEffect(() => {
-    if (savedMapLatLng) {
-      const { latitudeString, longitudeString } =
-        deriveGpsStringsFromValue(savedMapLatLng);
+    dispatch({
+      type: 'update-coordinates-externally',
+      payload: value,
+    });
+  }, [value]);
 
-      setCurrentLatitudeString(latitudeString);
-      setCurrentLongitudeString(longitudeString);
+  useEffect(() => {
+    if (setterType === 'internal') {
+      const latitude =
+        latitudeString === '' ? null : parseFloat(latitudeString);
+      const longitude =
+        longitudeString === '' ? null : parseFloat(longitudeString);
+      onChange([latitude, longitude]);
     }
-  }, [get(savedMapLatLng, '0'), get(savedMapLatLng, '1')]);
+  }, [latitudeString, longitudeString, setterType]); // onChange is intentionally excluded.
 
-  const currentLatitude = get(value, '0', null);
-  const currentLongitude = get(value, '1', null);
+  const onClose = () => {
+    dispatch({ type: 'select-map-coordinates', payload: null });
+    setModalOpen(false);
+  };
 
-  const onClose = () => setModalOpen(false);
   const showDescription = !minimalLabels && description;
 
   return (
@@ -74,26 +138,26 @@ export default function LatLongEditor({
           style={{ width }}
           id="gps-latitude"
           label={intl.formatMessage({ id: 'DECIMAL_LATITUDE' })}
-          value={currentLatitudeString}
+          value={latitudeString}
           type="number"
           onChange={e => {
-            const inputValue = e.target.value;
-            const floatValue = parseFloat(inputValue);
-            onChange([floatValue, currentLongitude]);
-            setCurrentLatitudeString(inputValue);
+            dispatch({
+              type: 'input-latitude',
+              payload: e.target.value,
+            });
           }}
         />
         <TextField
           style={{ width, margin: '8px 0' }}
           id="gps-longitude"
           label={intl.formatMessage({ id: 'DECIMAL_LONGITUDE' })}
-          value={currentLongitudeString}
+          value={longitudeString}
           type="number"
           onChange={e => {
-            const inputValue = e.target.value;
-            const floatValue = parseFloat(inputValue);
-            onChange([currentLatitude, floatValue]);
-            setCurrentLongitudeString(inputValue);
+            dispatch({
+              type: 'input-longitude',
+              payload: e.target.value,
+            });
           }}
         />
       </div>
@@ -116,7 +180,12 @@ export default function LatLongEditor({
       >
         <DialogContent style={{ marginBottom: 24 }}>
           <LatLngMap
-            onChange={clickedPoint => setMapLatLng(clickedPoint)}
+            onChange={clickedPoint => {
+              dispatch({
+                type: 'select-map-coordinates',
+                payload: clickedPoint,
+              });
+            }}
           />
         </DialogContent>
         <DialogActions style={{ padding: '0px 24px 24px 24px' }}>
@@ -124,8 +193,7 @@ export default function LatLongEditor({
           <Button
             display="primary"
             onClick={() => {
-              setSavedMapLatLng(mapLatLng);
-              onChange(mapLatLng);
+              dispatch({ type: 'confirm-map-coordinates' });
               onClose();
             }}
             id="CONFIRM"

--- a/src/components/fields/edit/LatLongEditor.jsx
+++ b/src/components/fields/edit/LatLongEditor.jsx
@@ -10,6 +10,19 @@ import Button from '../../Button';
 import StandardDialog from '../../StandardDialog';
 import useDescription from '../../../hooks/useDescription';
 
+const actionTypes = {
+  inputLatitude: 'input-latitude',
+  inputLongitude: 'input-longitude',
+  selectMapCoordinates: 'select-map-coordinates',
+  confirmMapCoordinates: 'confirm-map-coordinates',
+  updateCoordinatesExternally: 'update-coordinates-externally',
+};
+
+const setterTypes = {
+  internal: 'internal',
+  external: 'external',
+};
+
 function getNumberString(n) {
   if (n === 0) return '0';
   return n ? n.toString() : '';
@@ -20,35 +33,35 @@ function calculateInitialState(coordinates) {
     latitude: getNumberString(get(coordinates, '0', '')),
     longitude: getNumberString(get(coordinates, '1', '')),
     mapCoordinates: null,
-    setterType: 'external',
+    setterType: setterTypes.external,
   };
 }
 
 function reducer(state, action) {
   switch (action.type) {
-    case 'input-latitude':
+    case actionTypes.inputLatitude:
       return {
         ...state,
         latitude: action.payload,
-        setterType: 'internal',
+        setterType: setterTypes.internal,
       };
-    case 'input-longitude':
+    case actionTypes.inputLongitude:
       return {
         ...state,
         longitude: action.payload,
-        setterType: 'internal',
+        setterType: setterTypes.internal,
       };
-    case 'select-map-coordinates':
+    case actionTypes.selectMapCoordinates:
       return { ...state, mapCoordinates: action.payload };
-    case 'confirm-map-coordinates':
+    case actionTypes.confirmMapCoordinates:
       return {
         ...state,
         latitude: getNumberString(state.mapCoordinates?.[0]),
         longitude: getNumberString(state.mapCoordinates?.[1]),
         mapCoordinates: null,
-        setterType: 'internal',
+        setterType: setterTypes.internal,
       };
-    case 'update-coordinates-externally': {
+    case actionTypes.updateCoordinatesExternally: {
       const latitudeString = getNumberString(
         get(action.payload, '0', ''),
       );
@@ -70,7 +83,7 @@ function reducer(state, action) {
         ...state,
         latitude: latitudeString,
         longitude: longitudeString,
-        setterType: 'external',
+        setterType: setterTypes.external,
       };
     }
     default:
@@ -109,13 +122,13 @@ export default function LatLongEditor({
 
   useEffect(() => {
     dispatch({
-      type: 'update-coordinates-externally',
+      type: actionTypes.updateCoordinatesExternally,
       payload: value,
     });
   }, [value]);
 
   useEffect(() => {
-    if (setterType === 'internal') {
+    if (setterType === setterTypes.internal) {
       const latitude =
         latitudeString === '' ? null : parseFloat(latitudeString);
       const longitude =
@@ -125,7 +138,10 @@ export default function LatLongEditor({
   }, [latitudeString, longitudeString, setterType]); // onChange is intentionally excluded.
 
   const onClose = () => {
-    dispatch({ type: 'select-map-coordinates', payload: null });
+    dispatch({
+      type: actionTypes.selectMapCoordinates,
+      payload: null,
+    });
     setModalOpen(false);
   };
 
@@ -142,7 +158,7 @@ export default function LatLongEditor({
           type="number"
           onChange={e => {
             dispatch({
-              type: 'input-latitude',
+              type: actionTypes.inputLatitude,
               payload: e.target.value,
             });
           }}
@@ -155,7 +171,7 @@ export default function LatLongEditor({
           type="number"
           onChange={e => {
             dispatch({
-              type: 'input-longitude',
+              type: actionTypes.inputLongitude,
               payload: e.target.value,
             });
           }}
@@ -182,7 +198,7 @@ export default function LatLongEditor({
           <LatLngMap
             onChange={clickedPoint => {
               dispatch({
-                type: 'select-map-coordinates',
+                type: actionTypes.selectMapCoordinates,
                 payload: clickedPoint,
               });
             }}
@@ -193,7 +209,7 @@ export default function LatLongEditor({
           <Button
             display="primary"
             onClick={() => {
-              dispatch({ type: 'confirm-map-coordinates' });
+              dispatch({ type: actionTypes.confirmMapCoordinates });
               onClose();
             }}
             id="CONFIRM"

--- a/src/pages/sighting/EditSightingMetadata.jsx
+++ b/src/pages/sighting/EditSightingMetadata.jsx
@@ -56,22 +56,33 @@ export default function EditSightingMetadata({
   const [customFieldValues, setCustomFieldValues] = useState({});
 
   useEffect(() => {
-    const defaultFieldMetadata = metadata.filter(
-      field => !field.customField,
-    );
-    const customFieldMetadata = metadata.filter(
-      field => field.customField,
-    );
-    setDefaultFieldValues(
-      getInitialFormValues(defaultFieldMetadata, 'name'),
-    );
-    setCustomFieldValues(
-      getInitialFormValues(customFieldMetadata, 'id'),
-    );
-  }, [metadata, metadata?.length]);
+    // Only populate the form with the initial metadata values.
+    if (open) {
+      const defaultFieldMetadata = metadata.filter(
+        field => !field.customField,
+      );
+      const customFieldMetadata = metadata.filter(
+        field => field.customField,
+      );
+
+      setDefaultFieldValues(prev =>
+        metadata.length > 0 && isEmpty(prev)
+          ? getInitialFormValues(defaultFieldMetadata, 'name')
+          : prev,
+      );
+
+      setCustomFieldValues(prev =>
+        metadata.length > 0 && isEmpty(prev)
+          ? getInitialFormValues(customFieldMetadata, 'id')
+          : prev,
+      );
+    }
+  }, [open, metadata]);
 
   function handleClose() {
     clearError();
+    setDefaultFieldValues({});
+    setCustomFieldValues({});
     onClose();
   }
 
@@ -102,17 +113,15 @@ export default function EditSightingMetadata({
                 minimalLabels
                 onChange={newValue => {
                   if (field.customField) {
-                    const newFormValues = {
-                      ...customFieldValues,
+                    setCustomFieldValues(prev => ({
+                      ...prev,
                       [field.id]: newValue,
-                    };
-                    setCustomFieldValues(newFormValues);
+                    }));
                   } else {
-                    const newFormValues = {
-                      ...defaultFieldValues,
+                    setDefaultFieldValues(prev => ({
+                      ...prev,
                       [field.name]: newValue,
-                    };
-                    setDefaultFieldValues(newFormValues);
+                    }));
                   }
                 }}
               />

--- a/src/pages/sighting/OverviewContent.jsx
+++ b/src/pages/sighting/OverviewContent.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { get } from 'lodash-es';
 
 import CardContainer from '../../components/cards/CardContainer';
@@ -20,8 +20,12 @@ export default function OverviewContent({
     field =>
       !field.hideOnMetadataCard && Boolean(get(field, 'value')),
   );
-  const editableFields = metadata.filter(
-    field => field.editable && !field.hideOnMetadataCard,
+  const editableFields = useMemo(
+    () =>
+      metadata.filter(
+        field => field.editable && !field.hideOnMetadataCard,
+      ),
+    [metadata],
   );
 
   const gpsField = viewableMetadata.find(


### PR DESCRIPTION
Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x] ~All text is internationalized~ **No user facing text**
- [x] There are no linter errors
- [x] ~New features support all states (loading, error, etc)~ **No new features**

Which JIRA ticket(s) and/or GitHub issues does this PR address?
  - DEX-1401 - sighting metadata editing dialog sending incorrect payload to api

---

## Pull Request Overview

- Changes `LatLongEditor`'s state so that the inputs display the `value` passed in even when that value changes after the component has first mounted.
  - Changes `LatLongEditor`'s state handling to a reducer to more easily handle the related state.
- Updates `EditSightingMetadata` so that only the first change to the metadata dependency causes an update to the form values.
