### PR TITLE
DEX-1445 add info alert on splash setting and general settings pages …

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1193,5 +1193,6 @@
   "COLLABORATION_STATE_REVOKED": "Revoked",
   "EDIT_COLLABORATION": "Edit collaboration",
   "EDIT_COLLABORATION_CURRENT_STATE_LABEL": "Current state",
-  "EDIT_COLLABORATION_CURRENT_STATE_DESCRIPTION": "Changing the state will cancel any pending requests."
+  "EDIT_COLLABORATION_CURRENT_STATE_DESCRIPTION": "Changing the state will cancel any pending requests.",
+  "URLS_MUST_INCLUDE_HTTPS": "All URLs must include https:// to be valid"
 }

--- a/src/pages/generalSettings/GeneralSettings.jsx
+++ b/src/pages/generalSettings/GeneralSettings.jsx
@@ -114,6 +114,11 @@ export default function GeneralSettings() {
         direction="column"
         style={{ marginTop: 20, padding: 20 }}
       >
+        <CustomAlert
+          severity="info"
+          titleId="URLS_MUST_INCLUDE_HTTPS"
+        />
+
         <DividerTitle titleId="SITE_CONFIGURATION" />
         <SettingsTextInput
           settingKey="site.name"

--- a/src/pages/splashSettings/SplashSettings.jsx
+++ b/src/pages/splashSettings/SplashSettings.jsx
@@ -67,6 +67,10 @@ export default function SplashSettings() {
         direction="column"
         style={{ marginTop: 20, padding: 20 }}
       >
+        <CustomAlert
+          severity="info"
+          titleId="URLS_MUST_INCLUDE_HTTPS"
+        />
         <DividerTitle titleId="HERO_AREA" />
         <SettingsTextInput
           settingKey="site.general.tagline"


### PR DESCRIPTION
…to better guide end user to enter URLs correctly. Form validation improvements forthcoming in subsequent ticket

# Description

DEX-1445 was originally reported as an error in processing the URL of social media links.
Upon further investigation, the issue was that the user must provide the full URL, including the "https://" portion.

This is a form validation issue, and further inspection led to the discovery of several other form validation issues on the general settings page as well as the splash settings page.

It was decided that adding such form validation in the current effort was scope creep, so we are just putting a little bit of copy at the top of the page to suggest that the user type "https://". 

I decided that the text alone didn't look urgent enough, so I put it in an alert.

![Screen Shot 2022-09-26 at 4 08 39 PM](https://user-images.githubusercontent.com/2775448/192396362-5f5dcdc5-19b9-42a2-a10d-6e9bc22b2c99.png)



Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x] All text is internationalized
- [x] There are no linter errors
- [ ] New features support all states (loading, error, etc)
    - NA 

Which JIRA ticket(s) and/or GitHub issues does this PR address?

DEX-1445

Thanks for keeping it clean! Feel free to merge your own pull request after it has been approved - just use the "squash & merge" option.


