### PR TITLE
DEX-1443 cherry pick e8c4a2d from DEX-1443-empty-dropdown-as-array be…

### DIFF
--- a/src/constants/fieldTypes.js
+++ b/src/constants/fieldTypes.js
@@ -138,7 +138,7 @@ export const fieldTypeChoices = [
   {
     labelId: 'DROPDOWN',
     value: fieldTypes.select,
-    defaultValue: '',
+    defaultValue: null,
     backendType: backendTypes.string,
     backendMultiple: false,
     configuration: [
@@ -147,7 +147,7 @@ export const fieldTypeChoices = [
         descriptionId: 'DROPDOWN_CHOICE_HELPER_TEXT',
         value: 'choices',
         type: fieldTypes.optioneditor,
-        defaultValue: [],
+        defaultValue: null,
       },
     ],
   },

--- a/src/utils/fieldUtils.js
+++ b/src/utils/fieldUtils.js
@@ -114,7 +114,7 @@ const componentMap = {
     filterComponent: null,
   },
   [fieldTypes.select]: {
-    defaultValue: '',
+    defaultValue: null,
     fieldType: fieldTypes.select,
     viewComponent: SelectViewer,
     editComponent: SelectionEditor,


### PR DESCRIPTION
…cause there were commits in that branch that I did not make, so this felt like the cleaner solution

# Description

This is a companion PR with BE's [PR 810](https://github.com/WildMeOrg/houston/pull/810).

It makes the defaultValue for the customField select dropdowns null instead of an empty string.

It does not solve the remaining issue in DEX-1443, which has to do with the phrasing of the error message. IMO, this error message change should occur in the back end, because we are currently parroting out the errors that we see from them (which may change, as JVO pointed out to me, once we start internationalizing them as well).

Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x] All text is internationalized
- [x] There are no linter errors
- [ ] New features support all states (loading, error, etc)
    - NA

Which JIRA ticket(s) and/or GitHub issues does this PR address?

DEX-1443

Thanks for keeping it clean! Feel free to merge your own pull request after it has been approved - just use the "squash & merge" option.
