### PR TITLE
DEX-1314 extend itisIdSearch timeout to 1 min.

### DIFF
--- a/src/utils/useItisSearch.js
+++ b/src/utils/useItisSearch.js
@@ -16,7 +16,7 @@ export default function useItisSearch(searchKey, maxResults = 50) {
         jsonp(
           `https://www.itis.gov/ITISWebService/jsonservice/searchForAnyMatchPaged?srchKey=${searchKey}&pageSize=${maxResults}&pageNum=1&ascend=true`,
           {
-            timeout: 25000,
+            timeout: 60000,
             param: 'jsonp',
           },
           (err, response) => {


### PR DESCRIPTION
# Description

ItisIdSearch has historically been finicky and taken too long to perform.
The timeout has been extended to 1 minute.

Note/warning: I could not reproduce any difficulty with the ITIS Id search. The results were near-instantaneous for me.
This was true even when I turned wifi off on my machine. And when I used a private browser session. And when I cleared the cache.

I am not sure how to reproduce the historic issue, but I suspect that my one code change would do the trick in extending the timeout should it ever need it??

Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [ ] All text is internationalized
    NA
- [x] There are no linter errors
- [ ] New features support all states (loading, error, etc)
    NA

Which JIRA ticket(s) and/or GitHub issues does this PR address?

DEX-1314

Thanks for keeping it clean! Feel free to merge your own pull request after it has been approved - just use the "squash & merge" option.
