### PR TITLE
Dex 1313 add timeout user guidance

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1211,5 +1211,7 @@
   "EDIT_COLLABORATION_DENIED_BY_USER_MANAGER_MESSAGE": "An edit-level collaboration with {otherUserNameForManagerNotifications} was denied by a user manager {managerName}.",
   "EDIT_COLLABORATION_APPROVED_BY_USER_MANAGER": "Edit collaboration approved by a user manager",
   "EDIT_COLLABORATION_WAS_APPROVED_BY_A_USER_MANAGER": "An edit-level collaboration with {otherUserNameForManagerNotifications} was approved by a user manager {managerName}.",
-  "UNNAMED_MANAGER": "Unnamed manager"
+  "UNNAMED_MANAGER": "Unnamed manager",
+  "STILL_GENERATING_LIST": "Still generating list; this can take up to one minute.",
+  "SEARCH_TIMED_OUT_WHILE_TRYING_TO_CONNECT_TO_ITIS": "Search timed out while trying to connect to ITIS database. Try again later."
 }

--- a/src/pages/fieldManagement/settings/defaultFieldComponents/SpeciesEditor.jsx
+++ b/src/pages/fieldManagement/settings/defaultFieldComponents/SpeciesEditor.jsx
@@ -64,6 +64,12 @@ export default function SpeciesEditor({
     [],
   );
 
+  const isTimeoutError =
+    searchResultsError && searchResultsError?.indexOf('Timeout') > -1;
+  const isNonTimeoutError =
+    searchResultsError &&
+    searchResultsError?.indexOf('Timeout') === -1;
+
   const tableColumns = [
     {
       name: 'scientificName',
@@ -192,12 +198,17 @@ export default function SpeciesEditor({
             id="STILL_GENERATING_LIST"
           />
         )}
-        {searchResultsError && (
+        {isTimeoutError && (
           <CustomAlert
             style={{ marginTop: 12 }}
             severity="error"
             titleId="SEARCH_TIMED_OUT_WHILE_TRYING_TO_CONNECT_TO_ITIS"
           />
+        )}
+        {isNonTimeoutError && (
+          <CustomAlert style={{ marginTop: 12 }} severity="error">
+            {searchResultsError}
+          </CustomAlert>
         )}
         <DataDisplay
           cellStyles={{ padding: '0 8px 0 12px' }}

--- a/src/pages/fieldManagement/settings/defaultFieldComponents/SpeciesEditor.jsx
+++ b/src/pages/fieldManagement/settings/defaultFieldComponents/SpeciesEditor.jsx
@@ -197,9 +197,7 @@ export default function SpeciesEditor({
             style={{ marginTop: 12 }}
             severity="error"
             titleId="SEARCH_TIMED_OUT_WHILE_TRYING_TO_CONNECT_TO_ITIS"
-          >
-            {/* {searchResultsError} */}
-          </CustomAlert>
+          />
         )}
         <DataDisplay
           cellStyles={{ padding: '0 8px 0 12px' }}

--- a/src/pages/fieldManagement/settings/defaultFieldComponents/SpeciesEditor.jsx
+++ b/src/pages/fieldManagement/settings/defaultFieldComponents/SpeciesEditor.jsx
@@ -37,7 +37,6 @@ export default function SpeciesEditor({
     loading: searchResultsLoading,
     error: searchResultsError,
     setError,
-    setLoading,
   } = useItisSearch(searchTerm);
 
   const timerRef = useRef(null);
@@ -54,9 +53,8 @@ export default function SpeciesEditor({
     if (searchResultsError) {
       setStillGeneratingDisplay(false);
       clearTimeout(timerRef.current);
-      setLoading(false);
     }
-  }, [searchResultsError, searchResultsLoading, setLoading]);
+  }, [searchResultsLoading]);
   const currentSpecies = get(formSettings, 'species', []);
   const suggestedValues = get(
     siteSettings,
@@ -166,6 +164,7 @@ export default function SpeciesEditor({
           onSubmit={e => {
             setSearchTerm(searchInput);
             e.preventDefault();
+            setError(null);
           }}
           style={{ display: 'flex', alignItems: 'center' }}
         >
@@ -179,7 +178,6 @@ export default function SpeciesEditor({
           />
           <Button
             onClick={() => {
-              setError(null);
               setSearchTerm(searchInput);
             }}
             display="primary"

--- a/src/pages/fieldManagement/settings/defaultFieldComponents/SpeciesEditor.jsx
+++ b/src/pages/fieldManagement/settings/defaultFieldComponents/SpeciesEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { get } from 'lodash-es';
 import { useIntl, FormattedMessage } from 'react-intl';
 
@@ -40,33 +40,23 @@ export default function SpeciesEditor({
     setLoading,
   } = useItisSearch(searchTerm);
 
-  // const [searchResultsLoading, setSearchResultsLoading] =
-  //   useState(true);
-
-  let timer;
+  const timerRef = useRef(null);
   useEffect(() => {
-    console.log(
-      'deleteMe searchResultsLoading is: ' + searchResultsLoading,
-    );
-    console.log(
-      'deleteMe searchResultsError is: ' + searchResultsError,
-    );
     if (searchResultsLoading && !searchResultsError) {
-      timer = setTimeout(() => {
+      timerRef.current = setTimeout(() => {
         setStillGeneratingDisplay(true);
       }, '5000');
     }
     if (!searchResultsLoading) {
-      console.log('deleteMe should be clearing the timer now...');
       setStillGeneratingDisplay(false);
-      clearTimeout(timer);
+      clearTimeout(timerRef.current);
     }
     if (searchResultsError) {
       setStillGeneratingDisplay(false);
-      clearTimeout(timer);
+      clearTimeout(timerRef.current);
       setLoading(false);
     }
-  }, [searchResultsError, searchResultsLoading]);
+  }, [searchResultsError, searchResultsLoading, setLoading]);
   const currentSpecies = get(formSettings, 'species', []);
   const suggestedValues = get(
     siteSettings,

--- a/src/pages/fieldManagement/settings/defaultFieldComponents/SpeciesEditor.jsx
+++ b/src/pages/fieldManagement/settings/defaultFieldComponents/SpeciesEditor.jsx
@@ -49,6 +49,9 @@ export default function SpeciesEditor({
       setStillGeneratingDisplay(false);
       clearTimeout(timerRef.current);
     }
+    return () => {
+      clearTimeout(timerRef.current);
+    };
   }, [searchResultsLoading]);
   const currentSpecies = get(formSettings, 'species', []);
   const suggestedValues = get(

--- a/src/pages/fieldManagement/settings/defaultFieldComponents/SpeciesEditor.jsx
+++ b/src/pages/fieldManagement/settings/defaultFieldComponents/SpeciesEditor.jsx
@@ -41,16 +41,11 @@ export default function SpeciesEditor({
 
   const timerRef = useRef(null);
   useEffect(() => {
-    if (searchResultsLoading && !searchResultsError) {
+    if (searchResultsLoading) {
       timerRef.current = setTimeout(() => {
         setStillGeneratingDisplay(true);
       }, '5000');
-    }
-    if (!searchResultsLoading) {
-      setStillGeneratingDisplay(false);
-      clearTimeout(timerRef.current);
-    }
-    if (searchResultsError) {
+    } else {
       setStillGeneratingDisplay(false);
       clearTimeout(timerRef.current);
     }

--- a/src/utils/useItisSearch.js
+++ b/src/utils/useItisSearch.js
@@ -59,5 +59,5 @@ export default function useItisSearch(searchKey, maxResults = 50) {
     if (searchKey) fetchData();
   }, [searchKey, maxResults]);
 
-  return { data, loading, error };
+  return { data, loading, error, setError, setLoading };
 }

--- a/src/utils/useItisSearch.js
+++ b/src/utils/useItisSearch.js
@@ -20,7 +20,7 @@ export default function useItisSearch(searchKey, maxResults = 50) {
             param: 'jsonp',
           },
           (err, response) => {
-            if (err) setError(err);
+            if (err) setError(formatError(err));
 
             const results = get(response, 'anyMatchList');
             const formattedResults = results.map(result => {

--- a/src/utils/useItisSearch.js
+++ b/src/utils/useItisSearch.js
@@ -20,7 +20,11 @@ export default function useItisSearch(searchKey, maxResults = 50) {
             param: 'jsonp',
           },
           (err, response) => {
-            if (err) setError(formatError(err));
+            if (err) {
+              setError(formatError(err));
+              setLoading(false);
+              return;
+            }
 
             const results = get(response, 'anyMatchList');
             const formattedResults = results.map(result => {

--- a/src/utils/useItisSearch.js
+++ b/src/utils/useItisSearch.js
@@ -63,5 +63,5 @@ export default function useItisSearch(searchKey, maxResults = 50) {
     if (searchKey) fetchData();
   }, [searchKey, maxResults]);
 
-  return { data, loading, error, setError, setLoading };
+  return { data, loading, error, setError };
 }


### PR DESCRIPTION
# Description

If the end user is searching for a species to add to their codex instance, historically the potentially long search time for this and unreliability of the API has been a suboptimal user experience.

This PR introduces the following features:

1. After 5 seconds, if the search status is still loading and there's no error, the user will see an indication that the search is still underway:
<img width="1840" alt="Screen Shot 2022-10-14 at 2 50 45 PM" src="https://user-images.githubusercontent.com/2775448/195951117-5e7535af-5fe2-4106-a356-556fac5c0d95.png">

2. If the search errors out in any way, instead of whichever, if any, error message that would have been issued by the response, the end user will now see:
<img width="1840" alt="Screen Shot 2022-10-14 at 2 51 47 PM" src="https://user-images.githubusercontent.com/2775448/195951239-193fd889-e7ce-45b6-9aad-fe46f86eb1ad.png">

3. The end user will be able to search again, and either the error alert or the search status ("Still generating list...") will be dismissed.

4. The end user will not see either of these indicators if the search is faster than 5 seconds:

<img width="1840" alt="Screen Shot 2022-10-14 at 2 52 12 PM" src="https://user-images.githubusercontent.com/2775448/195951699-c08ab09c-a386-4e99-98d4-6e2757c3d8fb.png">

5. The end user will not see either of these indicators after the search is completed and there is no error:

<img width="1840" alt="Screen Shot 2022-10-14 at 2 52 12 PM" src="https://user-images.githubusercontent.com/2775448/195951679-6945b6ea-6bff-4bf8-b69f-4aa3b1a81d93.png">

6. The end user can click the search button again upon completion (successful or not) call to the ITIS api:
<img width="1840" alt="Screen Shot 2022-10-14 at 2 51 47 PM" src="https://user-images.githubusercontent.com/2775448/195951721-f08301b7-b95d-41d0-b2c6-d93dd5afee57.png">
OR
<img width="1840" alt="Screen Shot 2022-10-14 at 2 52 12 PM" src="https://user-images.githubusercontent.com/2775448/195951736-ce291c50-5f2c-4ad7-af79-b9e95f1d3747.png">


## QA Notes

- In order to reproduce a long search that does not complete before the 1-min. timeout, I just searched for the letter, "S".
- In order to reproduce a shorter search that does complete before the 1-min. timeout, I searched for, "Solenopsis".

Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x] All text is internationalized
- [x] There are no linter errors
- [x] New features support all states (loading, error, etc)

Which JIRA ticket(s) and/or GitHub issues does this PR address?

DEX-1313

Thanks for keeping it clean! Feel free to merge your own pull request after it has been approved - just use the "squash & merge" option.
