### PR TITLE
PR#846-frontend

### DIFF
--- a/src/pages/sighting/identification/buildMatchingSetQuery.js
+++ b/src/pages/sighting/identification/buildMatchingSetQuery.js
@@ -40,30 +40,35 @@ export default function buildMatchingSetQuery(regionSchema, region) {
   );
 
   return {
-    bool: {
-      filter: [
+    "bool": {
+      "minimum_should_match": 1,
+      "should": [
         {
-          bool: {
-            minimum_should_match: 1,
-            should: matchWithChildren.map(r => ({
-              term: {
-                locationId: r?.id,
+          "term": {
+            "git_store_guid": "_MACRO_annotation_git_store_guid"
+          }
+        },
+        {
+          "bool": {
+            "filter": [
+              {
+                "match": {
+                  "locationId": matchWithChildren.find(r => !!r.id).id                  
+                }
               },
-            })),
-          },
-        },
-        {
-          bool: '_MACRO_annotation_neighboring_viewpoints_clause',
-        },
-        {
-          exists: { field: 'encounter_guid' },
-        },
+              {
+                "exists": {
+                  "field": "encounter_guid"
+                }
+              }
+            ]
+          }
+        }
       ],
-      must_not: {
-        match: {
-          encounter_guid: '_MACRO_annotation_encounter_guid',
-        },
-      },
-    },
+      "must": {
+        "bool": "_MACRO_annotation_neighboring_viewpoints_clause"
+      }
+    }
+
   };
 }


### PR DESCRIPTION
Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x]  All text is internationalized N/A
- [x] There are no linter errors
- [x] New features support all states (loading, error, etc) N/A

Which JIRA ticket(s) and/or GitHub issues does this PR address?
This PR is for the frontend of PR#846 
Pull Request Overview
When a Bulk Import is done, the user (usually) commits the related sightings one at a time in sequence. Each commit (usually) triggers an ID job. The problem is, each ID jobs is matching against one (or more) additional Annotation than the previous, which is a nightmare for caching on Sage.

Proposed solution in this PR is to modify the matching-set query such that it will include all Annotations within the same AssetGroup so as to hopefully have a better chance of having cache-hits in Sage.

Modify Annotation Elasticsearch schema to include AssetGroup (aka GitStore) guid
Adjust matching-set query to including Annotations in same AssetGroup even when they have no Encounter (yet)

Thanks for keeping it clean! Feel free to merge your own pull request after it has been approved - just use the "squash & merge" option.
