### PR TITLE
next button also saves changes

### DIFF
--- a/src/pages/generalSettings/GeneralSettings.jsx
+++ b/src/pages/generalSettings/GeneralSettings.jsx
@@ -165,6 +165,7 @@ export default function GeneralSettings() {
   }
 
   function goForward() {
+    putSiteSetting({ property: '', data: currentValues });
     showContent(currentIndex+1);
   }
 
@@ -624,6 +625,7 @@ export default function GeneralSettings() {
                 {!Miscellaneous&&<Button style={{ marginTop: 12 }} 
                     display="primary"
                     onClick = {() => goForward(selectedLink)}
+                    disabled={!intelligentAgentFieldsValid && TwitterConfiguration}
                     >
                   Next
                 </Button>


### PR DESCRIPTION
1. when user clicks at next button, all changes will be saved
2. if user sets "allow twitter submissions" to true, but don't fill in required fields, next button on that page will be disabled