### PR TITLE
sightings metadata redesign

### DIFF
--- a/src/pages/sighting/AnnotationDetail.jsx
+++ b/src/pages/sighting/AnnotationDetail.jsx
@@ -27,6 +27,7 @@ export default function AnnotationDetail({
   onClose,
   refreshSightingData,
 }) {
+  const hasNoAnnotation = Boolean(annotation?.annotations);
   const intl = useIntl();
   const [anchorEl, setAnchorEl] = useState(null);
   const [addingTag, setAddingTag] = useState(false);
@@ -139,77 +140,78 @@ export default function AnnotationDetail({
               deletable
               refreshSightingData={refreshSightingData}
             >
-              {addingTag ? (
-                <div
-                  style={{ display: 'flex', alignItems: 'center' }}
-                >
-                  <Autocomplete
-                    id="tag value"
-                    freeSolo
-                    blurOnSelect
-                    clearOnEscape
-                    disableClearable
-                    handleHomeEndKeys
-                    selectOnFocus
-                    value={newTagSelectValue}
-                    onChange={(_, newValue) => {
-                      setNewTagSelectValue(newValue);
-                    }}
-                    inputValue={newTagInputValue}
-                    onInputChange={(_, newValue) => {
-                      if (newValue) setNewTagInputValue(newValue);
-                    }}
-                    disabled={addKeywordLoading}
-                    options={filteredKeywordOptions}
-                    getOptionLabel={option =>
-                      get(option, 'value', '')
-                    }
-                    renderOption={option => (
-                      <div
-                        style={{
-                          display: 'flex',
-                          alignItems: 'center',
-                        }}
-                      >
+              {!hasNoAnnotation &&
+                (addingTag ? (
+                  <div
+                    style={{ display: 'flex', alignItems: 'center' }}
+                  >
+                    <Autocomplete
+                      id="tag value"
+                      freeSolo
+                      blurOnSelect
+                      clearOnEscape
+                      disableClearable
+                      handleHomeEndKeys
+                      selectOnFocus
+                      value={newTagSelectValue}
+                      onChange={(_, newValue) => {
+                        setNewTagSelectValue(newValue);
+                      }}
+                      inputValue={newTagInputValue}
+                      onInputChange={(_, newValue) => {
+                        if (newValue) setNewTagInputValue(newValue);
+                      }}
+                      disabled={addKeywordLoading}
+                      options={filteredKeywordOptions}
+                      getOptionLabel={option =>
+                        get(option, 'value', '')
+                      }
+                      renderOption={option => (
                         <div
                           style={{
-                            width: 12,
-                            height: 12,
-                            marginRight: 8,
-                            borderRadius: 100,
-                            backgroundColor: getKeywordColor(
-                              option.guid,
-                            ),
+                            display: 'flex',
+                            alignItems: 'center',
                           }}
+                        >
+                          <div
+                            style={{
+                              width: 12,
+                              height: 12,
+                              marginRight: 8,
+                              borderRadius: 100,
+                              backgroundColor: getKeywordColor(
+                                option.guid,
+                              ),
+                            }}
+                          />
+                          <span>{option.value}</span>
+                        </div>
+                      )}
+                      renderInput={params => (
+                        <TextField
+                          {...params}
+                          autoFocus
+                          style={{ width: 200, margin: '0 8px' }}
                         />
-                        <span>{option.value}</span>
-                      </div>
-                    )}
-                    renderInput={params => (
-                      <TextField
-                        {...params}
-                        autoFocus
-                        style={{ width: 200, margin: '0 8px' }}
-                      />
-                    )}
-                  />
+                      )}
+                    />
+                    <Button
+                      display="panel"
+                      size="small"
+                      loading={addKeywordLoading}
+                      onClick={onAddTag}
+                      id="ADD_TAG"
+                    />
+                  </div>
+                ) : (
                   <Button
-                    display="panel"
+                    display="basic"
                     size="small"
-                    loading={addKeywordLoading}
-                    onClick={onAddTag}
+                    startIcon={<AddIcon />}
+                    onClick={() => setAddingTag(true)}
                     id="ADD_TAG"
                   />
-                </div>
-              ) : (
-                <Button
-                  display="basic"
-                  size="small"
-                  startIcon={<AddIcon />}
-                  onClick={() => setAddingTag(true)}
-                  id="ADD_TAG"
-                />
-              )}
+                ))}
             </Keywords>
           </div>
           <div

--- a/src/pages/sighting/Annotations.jsx
+++ b/src/pages/sighting/Annotations.jsx
@@ -6,6 +6,9 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import IconButton from '@material-ui/core/IconButton';
 import MoreIcon from '@material-ui/icons/MoreVert';
 
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Switch from '@material-ui/core/Switch';
+import { useIntl } from 'react-intl';
 import usePatchAnnotation from '../../models/annotation/usePatchAnnotation';
 import useDeleteAnnotation from '../../models/annotation/useDeleteAnnotation';
 import AnnotatedPhotograph from '../../components/AnnotatedPhotograph';
@@ -16,6 +19,8 @@ import MatchAnnotationDialog from './identification/MatchAnnotationDialog';
 import AnnotationDetail from './AnnotationDetail';
 import MoreAnnotationMenu from './MoreAnnotationMenu';
 import Keywords from './Keywords';
+import AnnotationCreator from '../../components/AnnotationCreator';
+import { formatFilename } from '../../utils/formatters';
 
 const useStyles = makeStyles({
   photoIcon: {
@@ -29,16 +34,20 @@ export default function Annotations({
   assets,
   refreshSightingData,
   pending,
+  sightingData,
 }) {
   const theme = useTheme();
   const isSm = useMediaQuery(theme.breakpoints.down('xs'));
   const classes = useStyles();
+  const intl = useIntl();
 
   const [detailId, setDetailId] = useState(null);
   const [editId, setEditId] = useState(null);
   const [deleteId, setDeleteId] = useState(null);
   const [matchId, setMatchId] = useState(null);
   const [anchorInfo, setAnchorInfo] = useState(null);
+  const [newAnnotationAsset, setNewAnnotationAsset] = useState(null);
+  const [showAnnotations, setShowAnnotations] = useState(true);
 
   const {
     deleteAnnotation,
@@ -57,130 +66,215 @@ export default function Annotations({
     const assetAnnotations = get(asset, 'annotations', []);
     const amendedAssetAnnotations = assetAnnotations.map(a => ({
       ...a,
+      asset,
       ...omit(asset, ['annotations', 'guid']),
     }));
     return [...acc, ...amendedAssetAnnotations];
   }, []);
+  const noAnnotations = assets
+    .filter(data => data.annotations.length === 0)
+    .map(a => {
+      a.asset = a;
+      return a;
+    });
 
   const clickedAnnotationId = get(anchorInfo, ['annotation', 'guid']);
-
+  const hasNoAnnotation = get(anchorInfo, [
+    'annotation',
+    'annotations',
+  ]);
   const detailAnnotation = annotations.find(a => a.guid === detailId);
-  const editAnnotation = annotations.find(a => a.guid === editId);
+  const detailNoAnnotation = noAnnotations.find(
+    a => a.guid === detailId,
+  );
 
+  const editAnnotation = annotations.find(a => a.guid === editId);
   return (
-    <div
-      style={{
-        display: 'grid',
-        columnGap: 12,
-        rowGap: 12,
-        gridTemplateColumns: isSm ? '1fr' : '1fr 1fr 1fr',
-        gridTemplateRows: 'auto',
-        gridAutoRows: 'auto',
-        margin: '0 20px',
-      }}
-    >
-      <MatchAnnotationDialog
-        annotationGuid={matchId}
-        open={Boolean(matchId)}
-        onClose={() => setMatchId(null)}
+    <>
+      <FormControlLabel
+        style={{ marginBottom: 8 }}
+        control={
+          <Switch
+            color="primary"
+            checked={showAnnotations}
+            onChange={e => setShowAnnotations(e.target.checked)}
+          />
+        }
+        label={intl.formatMessage({ id: 'SHOW_ANNOTATIONS' })}
       />
-      <AnnotationDetail
-        annotation={detailAnnotation}
-        open={Boolean(detailId)}
-        onClose={() => setDetailId(null)}
-        refreshSightingData={refreshSightingData}
-      />
-      <MoreAnnotationMenu
-        id="image-actions-menu"
-        pending={pending}
-        anchorEl={get(anchorInfo, 'element')}
-        open={Boolean(get(anchorInfo, 'element'))}
-        onClose={() => setAnchorInfo(null)}
-        onClickStartIdentification={() => {
-          setMatchId(clickedAnnotationId);
-          setAnchorInfo(null);
+
+      <div
+        style={{
+          display: 'grid',
+          columnGap: 12,
+          rowGap: 12,
+          gridTemplateColumns: isSm ? '1fr' : '1fr 1fr 1fr',
+          gridTemplateRows: 'auto',
+          gridAutoRows: 'auto',
+          // margin: '0 20px',
         }}
-        onClickEditAnnotation={() => {
-          setEditId(clickedAnnotationId);
-          setAnchorInfo(null);
-        }}
-        onClickDelete={() => {
-          setDeleteId(clickedAnnotationId);
-          setAnchorInfo(null);
-        }}
-      />
-      {editId && (
-        <AnnotationEditor
-          onClose={() => {
-            setEditId(null);
-            setAnnotationError(null);
+      >
+        <MatchAnnotationDialog
+          annotationGuid={matchId}
+          open={Boolean(matchId)}
+          onClose={() => setMatchId(null)}
+        />
+
+        {newAnnotationAsset && (
+          <AnnotationCreator
+            onClose={() => setNewAnnotationAsset(null)}
+            asset={newAnnotationAsset}
+            sightingData={sightingData}
+            pending={pending}
+          />
+        )}
+        <AnnotationDetail
+          annotation={detailAnnotation || detailNoAnnotation}
+          open={Boolean(detailId)}
+          onClose={() => setDetailId(null)}
+          refreshSightingData={refreshSightingData}
+        />
+        <MoreAnnotationMenu
+          id="image-actions-menu"
+          pending={pending}
+          disable={!!hasNoAnnotation}
+          anchorEl={get(anchorInfo, 'element')}
+          open={Boolean(get(anchorInfo, 'element'))}
+          onClose={() => setAnchorInfo(null)}
+          onClickStartIdentification={() => {
+            setMatchId(clickedAnnotationId);
+            setAnchorInfo(null);
           }}
-          onChange={async rect => {
-            const coords = [
-              get(rect, 'percentLeft'),
-              get(rect, 'percentTop'),
-              get(rect, 'percentWidth'),
-              get(rect, 'percentHeight'),
-            ];
-            const updateSuccessful = await updateAnnotationProperty(
-              editId,
-              'bounds',
-              { rect: coords, theta: get(rect, 'theta', 0) },
+          onClickEditAnnotation={() => {
+            setEditId(clickedAnnotationId);
+            setAnchorInfo(null);
+          }}
+          onClickAddAnnotation={() => {
+            setAnchorInfo(null);
+            setNewAnnotationAsset(
+              get(anchorInfo, ['annotation', 'asset']),
             );
-            if (updateSuccessful) {
+          }}
+          onClickDelete={() => {
+            setDeleteId(clickedAnnotationId);
+            setAnchorInfo(null);
+          }}
+        />
+        {editId && (
+          <AnnotationEditor
+            onClose={() => {
               setEditId(null);
+              setAnnotationError(null);
+            }}
+            onChange={async rect => {
+              const coords = [
+                get(rect, 'percentLeft'),
+                get(rect, 'percentTop'),
+                get(rect, 'percentWidth'),
+                get(rect, 'percentHeight'),
+              ];
+              const updateSuccessful = await updateAnnotationProperty(
+                editId,
+                'bounds',
+                { rect: coords, theta: get(rect, 'theta', 0) },
+              );
+              if (updateSuccessful) {
+                setEditId(null);
+                refreshSightingData();
+              }
+            }}
+            disableDelete
+            error={patchError}
+            loading={patchInProgress}
+            imgSrc={get(editAnnotation, 'src')}
+            annotations={[editAnnotation]}
+          />
+        )}
+        <ConfirmDelete
+          open={Boolean(deleteId)}
+          onClose={() => setDeleteId(null)}
+          onDelete={async () => {
+            const deleteSuccessful = await deleteAnnotation(deleteId);
+            if (deleteSuccessful) {
+              setDeleteId(null);
               refreshSightingData();
             }
           }}
-          disableDelete
-          error={patchError}
-          loading={patchInProgress}
-          imgSrc={get(editAnnotation, 'src')}
-          annotations={[editAnnotation]}
+          deleteInProgress={deleteInProgress}
+          error={deleteAnnotationError}
+          onClearError={() => deleteAnnotationError(null)}
+          messageId="CONFIRM_DELETE_ANNOTATION_DESCRIPTION"
         />
-      )}
-      <ConfirmDelete
-        open={Boolean(deleteId)}
-        onClose={() => setDeleteId(null)}
-        onDelete={async () => {
-          const deleteSuccessful = await deleteAnnotation(deleteId);
-          if (deleteSuccessful) {
-            setDeleteId(null);
-            refreshSightingData();
-          }
-        }}
-        deleteInProgress={deleteInProgress}
-        error={deleteAnnotationError}
-        onClearError={() => deleteAnnotationError(null)}
-        messageId="CONFIRM_DELETE_ANNOTATION_DESCRIPTION"
-      />
-      {annotations.length === 0 ? (
-        <Text id="NO_ANNOTATIONS_MESSAGE" />
-      ) : null}
-      {annotations.map(annotation => (
-        <div key={annotation.guid} style={{ position: 'relative' }}>
-          <AnnotatedPhotograph
-            assetMetadata={annotation}
-            annotations={[annotation]}
-            onClick={() => setDetailId(annotation.guid)}
-          />
-          <IconButton
-            onClick={e =>
-              setAnchorInfo({ element: e.currentTarget, annotation })
-            }
-            style={{
-              position: 'absolute',
-              top: 4,
-              right: 4,
-              color: theme.palette.common.white,
-            }}
-            className={classes.photoIcon}
-          >
-            <MoreIcon />
-          </IconButton>
-          <Keywords annotation={annotation} />
-        </div>
-      ))}
-    </div>
+        {annotations.length === 0 ? (
+          <Text id="NO_ANNOTATIONS_MESSAGE" />
+        ) : null}
+
+        {annotations.map(annotation => (
+          <div key={annotation.guid} style={{ position: 'relative' }}>
+            <AnnotatedPhotograph
+              assetMetadata={annotation}
+              annotations={showAnnotations ? [annotation] : []}
+              onClick={() => {
+                setDetailId(annotation.guid);
+              }}
+            />
+            <IconButton
+              onClick={e => {
+                setAnchorInfo({
+                  element: e.currentTarget,
+                  annotation,
+                });
+              }}
+              style={{
+                position: 'absolute',
+                top: 4,
+                right: 4,
+                color: theme.palette.common.white,
+              }}
+              className={classes.photoIcon}
+            >
+              <MoreIcon />
+            </IconButton>
+            <Text variant="caption">
+              {formatFilename(annotation.asset.filename, 35)}
+            </Text>
+            <Keywords annotation={annotation} />
+          </div>
+        ))}
+
+        {noAnnotations.map(annotation => (
+          <div key={annotation.guid} style={{ position: 'relative' }}>
+            <AnnotatedPhotograph
+              assetMetadata={annotation}
+              annotations={[]}
+              onClick={() => {
+                setDetailId(annotation.guid);
+              }}
+            />
+            <IconButton
+              onClick={e => {
+                setAnchorInfo({
+                  element: e.currentTarget,
+                  annotation,
+                });
+              }}
+              style={{
+                position: 'absolute',
+                top: 4,
+                right: 4,
+                color: theme.palette.common.white,
+              }}
+              className={classes.photoIcon}
+            >
+              <MoreIcon />
+            </IconButton>
+            <Text variant="caption">
+              {formatFilename(annotation.filename, 35)}
+            </Text>
+            <Keywords annotation={annotation} />
+          </div>
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/pages/sighting/MoreAnnotationMenu.jsx
+++ b/src/pages/sighting/MoreAnnotationMenu.jsx
@@ -13,6 +13,8 @@ export default function MoreAnnotationMenu({
   // onClickStartIdentification = Function.prototype,
   // onClickEditAnnotation = Function.prototype,
   onClickDelete = Function.prototype,
+  onClickAddAnnotation = Function.prototype,
+  disable = false,
 }) {
   return (
     <Menu id={id} anchorEl={anchorEl} open={open} onClose={onClose}>
@@ -25,7 +27,10 @@ export default function MoreAnnotationMenu({
       >
         <FormattedMessage id="START_IDENTIFICATION" />
       </MenuItem> */}
-      <MenuItem onClick={onClickDelete}>
+      <MenuItem onClick={onClickAddAnnotation}>
+        <FormattedMessage id="ADD_ANNOTATION" />
+      </MenuItem>
+      <MenuItem disabled={disable} onClick={onClickDelete}>
         <FormattedMessage id="DELETE_ANNOTATION" />
       </MenuItem>
     </Menu>

--- a/src/pages/sighting/SightingCore.jsx
+++ b/src/pages/sighting/SightingCore.jsx
@@ -19,7 +19,7 @@ import useDeleteAssetGroupSighting from '../../models/assetGroupSighting/useDele
 import useSightingFieldSchemas from '../../models/sighting/useSightingFieldSchemas';
 import SightingEntityHeader from './SightingEntityHeader';
 import Annotations from './Annotations';
-import Photographs from './Photographs';
+// import Photographs from './Photographs';
 import OverviewContent from './OverviewContent';
 // import SightingHistoryDialog from './SightingHistoryDialog';
 import CommitBanner from './CommitBanner';
@@ -202,17 +202,18 @@ export default function SightingCore({
           refreshSightingData={refreshData}
         />
       )}
-      {activeTab === '#photographs' && (
+      {/* {activeTab === '#photographs' && (
         <Photographs
           assets={assets}
           sightingData={data}
           pending={pending}
         />
-      )}
+      )} */}
       {activeTab === '#annotations' && (
         <Annotations
           assets={assets}
           refreshSightingData={refreshData}
+          sightingData={data}
           pending={pending}
         />
       )}

--- a/src/pages/sighting/SightingEntityHeader.jsx
+++ b/src/pages/sighting/SightingEntityHeader.jsx
@@ -22,10 +22,10 @@ const tabItems = [
     labelId: 'OVERVIEW',
     value: 'overview',
   },
-  {
-    labelId: 'PHOTOGRAPHS',
-    value: 'photographs',
-  },
+  // {
+  //   labelId: 'PHOTOGRAPHS',
+  //   value: 'photographs',
+  // },
   {
     labelId: 'ANNOTATIONS',
     value: 'annotations',


### PR DESCRIPTION
sightings metadata page:
1. remove photograph tab
2. on annotations tab, display images with or without annotations
3. add "add annotations" button to the 3dot button
4. when click at an image that has no annotations, "add tag" is hidden, we can't add tag to image that has no annotation