### PR TITLE
503-nested-regions

### DIFF
--- a/src/pages/sighting/identification/CommitDialog.jsx
+++ b/src/pages/sighting/identification/CommitDialog.jsx
@@ -76,6 +76,7 @@ export default function CommitDialog({ agsGuid, open, onClose }) {
           <CustomMatchingSetForm
             idConfig={idConfig}
             setIdConfig={setIdConfig}
+            nested
           />
         )}
         {error && (

--- a/src/pages/sighting/identification/CustomMatchingSetForm.jsx
+++ b/src/pages/sighting/identification/CustomMatchingSetForm.jsx
@@ -9,6 +9,7 @@ import buildMatchingSetQuery from './buildMatchingSetQuery';
 export default function CustomMatchingSetForm({
   // idConfig, // use this to get matching set size!
   setIdConfig,
+  nested,
 }) {
   const idConfigSchemas = useIdConfigSchemas();
 
@@ -29,7 +30,11 @@ export default function CustomMatchingSetForm({
   useEffect(() => {
     setIdConfig({
       algorithms,
-      matching_set: buildMatchingSetQuery(regionSchema, region),
+      matching_set: buildMatchingSetQuery(
+        regionSchema,
+        region,
+        nested,
+      ),
     });
   }, [
     setIdConfig,

--- a/src/pages/sighting/identification/CustomMatchingSetForm.jsx
+++ b/src/pages/sighting/identification/CustomMatchingSetForm.jsx
@@ -9,7 +9,7 @@ import buildMatchingSetQuery from './buildMatchingSetQuery';
 export default function CustomMatchingSetForm({
   // idConfig, // use this to get matching set size!
   setIdConfig,
-  nested,
+  nested = false,
 }) {
   const idConfigSchemas = useIdConfigSchemas();
 
@@ -26,7 +26,6 @@ export default function CustomMatchingSetForm({
 
   const [algorithms, setAlgorithms] = useState([]);
   const [region, setRegion] = useState('');
-
   useEffect(() => {
     setIdConfig({
       algorithms,

--- a/src/pages/sighting/identification/RerunIdentificationDialog.jsx
+++ b/src/pages/sighting/identification/RerunIdentificationDialog.jsx
@@ -39,6 +39,7 @@ export default function RerunIdentificationDialog({
         <CustomMatchingSetForm
           idConfig={idConfig}
           setIdConfig={setIdConfig}
+          nested
         />
         {error && (
           <CustomAlert severity="error" titleId="SERVER_ERROR">


### PR DESCRIPTION
on sightings "re-run identification" page and and "commit sighting custom identification" page, when select a top level region, its sub regions will be all included.