### PR TITLE
match-status-patch

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -1265,5 +1265,6 @@
   "LAST_FREEFORM" : "Last freeform",
   "UNREVIEWED" : "Unreviewed",
   "REVIEWED" : "Reviewed",
-  "IN_PROGRESS" : "In progress"
+  "IN_PROGRESS" : "In progress",
+  "UNPROCESSED" : "Unprocessed"
 }

--- a/src/components/dialogs/ReviewSighting.jsx
+++ b/src/components/dialogs/ReviewSighting.jsx
@@ -66,13 +66,14 @@ export default function ReviewSighting({
         buttonId="match-actions"
         style={{ marginLeft: 24 }}
         actions={buttonActions}
-        id={matchStatus?.toUpperCase()}
+        id={matchStatus?.toUpperCase() || 'UNPROCESSED'}
+        disabled={!matchStatus}
       />
       {error && (
         <Alert
           severity="error"
           onClose={clearError}
-          style={{ margin: '16px 0' }}
+          style={{ margin: '16px 16px', maxWidth: 400 }}
         >
           {error}
         </Alert>


### PR DESCRIPTION
add 'unprocessed' status for uncommitted sightings on sightings page, the button will be disabled if the sighting is not committed.