### PR TITLE
Region editor remodel

### DIFF
--- a/src/components/fields/edit/LocationIdEditor.jsx
+++ b/src/components/fields/edit/LocationIdEditor.jsx
@@ -73,9 +73,9 @@ export default function LocationIdEditor(props) {
   
   const select = (event) => {
     const dropdown = document.querySelector('#treeViewDemo');
-    if(event.target.classList.contains('MuiSvgIcon-root') || 
+    if(event.target?.classList?.contains('MuiSvgIcon-root') || 
       dropdown.contains(event.target) || 
-      event.target.parentNode.classList.contains('MuiSvgIcon-root')
+      event.target?.parentNode?.classList?.contains('MuiSvgIcon-root')
       ) {
       setModalOpen(true);
     }else {

--- a/src/components/fields/edit/LocationIdEditor.jsx
+++ b/src/components/fields/edit/LocationIdEditor.jsx
@@ -6,7 +6,7 @@ import useDescription from '../../../hooks/useDescription';
 import useEditLabel from '../../../hooks/useEditLabel';
 import FormCore from './FormCore';
 import { useState } from 'react';
-import TreeViewDemo from './TreeViewDemo';
+import TreeViewComponent from './TreeViewComponent';
 import _ from 'lodash-es';
 
 export default function LocationIdEditor(props) {
@@ -54,7 +54,7 @@ export default function LocationIdEditor(props) {
     }
 
     const validNodes = _.keys(nameToIdMap)
-    .filter(name => name.toLowerCase().includes(searchText.toLowerCase()))
+    .filter(name => name?.toLowerCase().includes(searchText.toLowerCase()))
     .map(name => {
       const id = nameToIdMap[name];
       const node1 = flatternedTree[id];
@@ -107,7 +107,7 @@ export default function LocationIdEditor(props) {
           onChange={handleSearchChange}
         />
         {modalOpen && 
-          <TreeViewDemo 
+          <TreeViewComponent 
             onChange={onChange} 
             searchText={searchText}
             showData={showData}

--- a/src/components/fields/edit/LocationIdEditor.jsx
+++ b/src/components/fields/edit/LocationIdEditor.jsx
@@ -3,7 +3,7 @@ import FormHelperText from '@material-ui/core/FormHelperText';
 import { Autocomplete } from '@material-ui/lab';
 import { TextField } from '@material-ui/core';
 import { get } from 'lodash-es';
-import Text from '../../Text';
+import Radio from '@material-ui/core/Radio';
 import useDescription from '../../../hooks/useDescription';
 import useEditLabel from '../../../hooks/useEditLabel';
 import FormCore from './FormCore';
@@ -35,19 +35,71 @@ export default function LocationIdEditor(props) {
     : null;
   const currentRegion = get(currentRegionArray, [0], null);
 
+  const filterOptions = (options, { inputValue }) => {
+    console.log('options', options);
+    console.log('inputValue', inputValue);
+
+    if (inputValue) {
+      // const filteredOptions = options.filter(option =>
+      //   option.name.toLowerCase().includes(inputValue.toLowerCase())
+      // );
+
+      return options;
+    }
+
+    return options;
+  };
+
   return (
     <FormCore schema={schema} width={width}>
       <Autocomplete
         value={currentRegion}
         options={collapsedChoices}
-        renderOption={option => (
-          <Text
-            style={{ paddingLeft: option.depth * 10 }}
-            value={option.id}
-          >
-            {option.name}
-          </Text>
-        )}
+        disableCloseOnSelect
+        filterOptions={filterOptions}
+        // renderOption={option => (
+        //   <Text
+        //     style={{ paddingLeft: option.depth * 10 }}
+        //     value={option.id}
+        //   >
+        //     {option.name}
+        //   </Text>
+        // )}
+        renderOption={(option, { selected, inputValue }) => {
+          const searchResult = option.name
+            .toLowerCase()
+            .includes(inputValue.toLowerCase());
+
+          return (
+            <>
+              <Radio
+                style={{
+                  paddingLeft: option.depth * 10,
+                  fontSize: 5,
+                }}
+                checked={selected || searchResult}
+                value={option.id}
+                onChange={() => {}}
+                color="primary"
+                inputProps={{ 'aria-labelledby': option.id }}
+              />
+              {searchResult ? (
+                <span
+                  style={{
+                    fontSize: 42,
+                    paddingLeft: option.depth * 10,
+                  }}
+                >
+                  {option.name}
+                </span>
+              ) : (
+                <span style={{ paddingLeft: option.depth * 10 }}>
+                  {option.name}
+                </span>
+              )}
+            </>
+          );
+        }}
         onChange={(_, newValue) => {
           if (multiple) {
             onChange(
@@ -62,12 +114,14 @@ export default function LocationIdEditor(props) {
           option.id ? option.id === get(currentRegion, 'id') : false
         }
         renderInput={params => (
-          <TextField
-            {...params}
-            style={{ width: 280 }}
-            variant="standard"
-            label={editLabel}
-          />
+          <div>
+            <TextField
+              {...params}
+              style={{ width: 280 }}
+              variant="standard"
+              label={editLabel}
+            />
+          </div>
         )}
         multiple={multiple}
         {...rest}

--- a/src/components/fields/edit/LocationIdEditor.jsx
+++ b/src/components/fields/edit/LocationIdEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import { Autocomplete } from '@material-ui/lab';
 import { TextField } from '@material-ui/core';
@@ -8,6 +8,7 @@ import useDescription from '../../../hooks/useDescription';
 import useEditLabel from '../../../hooks/useEditLabel';
 import FormCore from './FormCore';
 import { collapseChoices } from '../../../utils/formatters';
+import { set } from 'date-fns';
 
 export default function LocationIdEditor(props) {
   const {
@@ -30,10 +31,42 @@ export default function LocationIdEditor(props) {
     [get(schema, 'choices.length')],
   );
 
+  console.log(get(schema, 'choices', []), 0)
+
   const currentRegionArray = value
     ? collapsedChoices.filter(choice => get(choice, 'id') === value)
     : null;
   const currentRegion = get(currentRegionArray, [0], null);
+  console.log("currentRegion", currentRegion);
+
+  const [subRegion, setSubRegion] = React.useState([]);
+
+  useEffect(() => { 
+    if(collapsedChoices?.length && currentRegion) {
+      console.log("======>>>>>>>>>",collapsedChoices);
+      const selectedIndex = collapsedChoices?.findIndex(data => data.id === currentRegion.id);
+      console.log("selectedIndex", selectedIndex);
+      const subRegion1 = [];
+
+      for (let i = selectedIndex + 1; i < collapsedChoices?.length; i++) {
+        const currentOption = collapsedChoices[i];  
+        if (currentOption.depth > currentRegion?.depth) {
+          subRegion1.push(currentOption);
+          
+        } else if (currentOption.depth <= currentRegion.depth) {
+          break;
+        }
+      }
+
+      setSubRegion(subRegion1);
+
+  console.log("subRegion", subRegion);
+    }
+    
+  
+
+  }, [currentRegion]);
+
 
   const filterOptions = (options, { inputValue }) => {
     console.log('options', options);
@@ -68,20 +101,22 @@ export default function LocationIdEditor(props) {
         renderOption={(option, { selected, inputValue }) => {
           const searchResult = option.name
             .toLowerCase()
-            .includes(inputValue.toLowerCase());
+            .includes(inputValue.toLowerCase() || 'A');
+            // console.log("option", option);
+          
 
           return (
             <>
               <Radio
                 style={{
                   paddingLeft: option.depth * 10,
-                  fontSize: 5,
                 }}
-                checked={selected || searchResult}
+                checked={selected}
                 value={option.id}
-                onChange={() => {}}
+                // onChange={() => {}}
                 color="primary"
-                inputProps={{ 'aria-labelledby': option.id }}
+                size="small"
+                // inputProps={{ 'aria-labelledby': option.id }}
               />
               {searchResult ? (
                 <span

--- a/src/components/fields/edit/LocationIdEditor.jsx
+++ b/src/components/fields/edit/LocationIdEditor.jsx
@@ -2,13 +2,19 @@ import React, { useEffect, useMemo } from 'react';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import { Autocomplete } from '@material-ui/lab';
 import { TextField } from '@material-ui/core';
-import { get } from 'lodash-es';
+import { filter, get } from 'lodash-es';
 import Radio from '@material-ui/core/Radio';
 import useDescription from '../../../hooks/useDescription';
 import useEditLabel from '../../../hooks/useEditLabel';
 import FormCore from './FormCore';
 import { collapseChoices } from '../../../utils/formatters';
-import { set } from 'date-fns';
+import { flattenDeep } from 'lodash-es';
+import { set, sub } from 'date-fns';
+import { useState } from 'react';
+import TreeViewDemo from './TreeViewDemo';
+import Button from '../../Button';
+import { FormattedMessage } from 'react-intl';
+
 
 export default function LocationIdEditor(props) {
   const {
@@ -31,139 +37,142 @@ export default function LocationIdEditor(props) {
     [get(schema, 'choices.length')],
   );
 
-  console.log(get(schema, 'choices', []), 0)
-
   const currentRegionArray = value
     ? collapsedChoices.filter(choice => get(choice, 'id') === value)
     : null;
   const currentRegion = get(currentRegionArray, [0], null);
-  console.log("currentRegion", currentRegion);
 
-  const [subRegion, setSubRegion] = React.useState([]);
+  const [modalOpen, setModalOpen] = useState(false);
 
-  useEffect(() => { 
-    if(collapsedChoices?.length && currentRegion) {
-      console.log("======>>>>>>>>>",collapsedChoices);
-      const selectedIndex = collapsedChoices?.findIndex(data => data.id === currentRegion.id);
-      console.log("selectedIndex", selectedIndex);
-      const subRegion1 = [];
+  // function getSubRegion(selectedRegion) {
+  //   const selectedIndex = collapsedChoices?.findIndex(data => data.id === selectedRegion.id);
+  //     const subRegion = [];
 
-      for (let i = selectedIndex + 1; i < collapsedChoices?.length; i++) {
-        const currentOption = collapsedChoices[i];  
-        if (currentOption.depth > currentRegion?.depth) {
-          subRegion1.push(currentOption);
-          
-        } else if (currentOption.depth <= currentRegion.depth) {
-          break;
-        }
-      }
+  //     for (let i = selectedIndex + 1; i < collapsedChoices?.length; i++) {
+  //       const currentOption = collapsedChoices[i];  
+  //       if (currentOption.depth > selectedRegion?.depth) {
+  //         subRegion.push(currentOption);          
+  //       } else if (currentOption.depth <= selectedRegion.depth) {
+  //         break;
+  //       }
+  //     }
+  //     return subRegion;
+  // }
 
-      setSubRegion(subRegion1);
-
-  console.log("subRegion", subRegion);
-    }
+  // const filterOptions = (options, { inputValue }) => {
+  //   const subRegion = [];
+  //   if (inputValue) {
+  //     const filteredOptions = options.filter(option =>
+  //       option.name.toLowerCase().includes(inputValue.toLowerCase())
+  //     );
+      
+  //     if (filteredOptions) {
+  //       filteredOptions.forEach(data => {
+  //         subRegion.push(data);
+  //         subRegion.push(...getSubRegion(data));
+  //         console.log('subRegion', subRegion);
+  //       });
+        
+  //     }    
+  //     const uniqueArray = Array.from(new Set(subRegion.map(obj => obj.id)))
+  //      .map(id => subRegion.find(obj => obj.id === id));
+  //     console.log('uniqueArray', uniqueArray);
+  //     return uniqueArray
     
-  
+  //   }
 
-  }, [currentRegion]);
+  //   return options;
+  // };
 
+  // return (
+  //   <FormCore schema={schema} width={width}>
+  //     <Autocomplete
+  //       value={currentRegion}
+  //       options={collapsedChoices}
+  //       disableCloseOnSelect
+  //       // filterOptions={filterOptions}        
+  //       // renderOption={option => (
+  //       //   <Text
+  //       //     style={{ paddingLeft: option.depth * 10 }}
+  //       //     value={option.id}
+  //       //   >
+  //       //     {option.name}
+  //       //   </Text>
+  //       // )}
+  //       renderOption={(option, { selected, inputValue }) => {
+  //         // const searchResult = option.name
+  //         //   .toLowerCase()
+  //         //   .includes(inputValue.toLowerCase() || 'A');
+          
 
-  const filterOptions = (options, { inputValue }) => {
-    console.log('options', options);
-    console.log('inputValue', inputValue);
+  //         return (
+  //           <>
+  //             <Radio
+  //               style={{
+  //                 paddingLeft: option.depth * 10,
+  //               }}
+  //               checked={selected}
+  //               value={option.id}
+  //               onChange={() => {}}
+  //               color="primary"
+  //               size="small"
+  //               inputProps={{ 'aria-labelledby': option.id }}
+  //             />
 
-    if (inputValue) {
-      // const filteredOptions = options.filter(option =>
-      //   option.name.toLowerCase().includes(inputValue.toLowerCase())
-      // );
+  //               <span                   
+  //                 style={{ paddingLeft: option.depth * 10 }}>
+  //                 {option.name}
+  //               </span>
 
-      return options;
-    }
+  //           </>
+  //         );
+  //       }}
+  //       onChange={(_, newValue) => {
+  //         if (multiple) {
+  //           onChange(
+  //             newValue.map(location => get(location, 'id', '')),
+  //           );
+  //         } else {
+  //           onChange(get(newValue, 'id', ''));
+  //         }
+  //       }}
+  //       getOptionLabel={option => get(option, 'name', '')}
+  //       getOptionSelected={option =>
+  //         option.id ? option.id === get(currentRegion, 'id') : false
+  //       }
+  //       renderInput={params => (
+  //         <div>
+  //           <TextField
+  //             {...params}
+  //             style={{ width: 280 }}
+  //             variant="standard"
+  //             label={editLabel}
+  //           />
+  //         </div>
+  //       )}
+  //       multiple={multiple}
+  //       {...rest}
+  //     />
+  //     {showDescription ? (
+  //       <FormHelperText>{description}</FormHelperText>
+  //     ) : null}
+  //   </FormCore>
+  // );
 
-    return options;
-  };
 
   return (
     <FormCore schema={schema} width={width}>
-      <Autocomplete
-        value={currentRegion}
-        options={collapsedChoices}
-        disableCloseOnSelect
-        filterOptions={filterOptions}
-        // renderOption={option => (
-        //   <Text
-        //     style={{ paddingLeft: option.depth * 10 }}
-        //     value={option.id}
-        //   >
-        //     {option.name}
-        //   </Text>
-        // )}
-        renderOption={(option, { selected, inputValue }) => {
-          const searchResult = option.name
-            .toLowerCase()
-            .includes(inputValue.toLowerCase() || 'A');
-            // console.log("option", option);
-          
+      <Button
+        style={{
+          width:"100%",
 
-          return (
-            <>
-              <Radio
-                style={{
-                  paddingLeft: option.depth * 10,
-                }}
-                checked={selected}
-                value={option.id}
-                // onChange={() => {}}
-                color="primary"
-                size="small"
-                // inputProps={{ 'aria-labelledby': option.id }}
-              />
-              {searchResult ? (
-                <span
-                  style={{
-                    fontSize: 42,
-                    paddingLeft: option.depth * 10,
-                  }}
-                >
-                  {option.name}
-                </span>
-              ) : (
-                <span style={{ paddingLeft: option.depth * 10 }}>
-                  {option.name}
-                </span>
-              )}
-            </>
-          );
+          borderBottom: '1px solid #ccc',
         }}
-        onChange={(_, newValue) => {
-          if (multiple) {
-            onChange(
-              newValue.map(location => get(location, 'id', '')),
-            );
-          } else {
-            onChange(get(newValue, 'id', ''));
-          }
-        }}
-        getOptionLabel={option => get(option, 'name', '')}
-        getOptionSelected={option =>
-          option.id ? option.id === get(currentRegion, 'id') : false
-        }
-        renderInput={params => (
-          <div>
-            <TextField
-              {...params}
-              style={{ width: 280 }}
-              variant="standard"
-              label={editLabel}
-            />
-          </div>
-        )}
-        multiple={multiple}
-        {...rest}
-      />
-      {showDescription ? (
-        <FormHelperText>{description}</FormHelperText>
-      ) : null}
-    </FormCore>
-  );
+        onClick={() => {setModalOpen(!modalOpen)}} 
+        >
+        <FormattedMessage id="SEARCH_REGION" />
+      </Button>
+      {modalOpen && <TreeViewDemo onChange={onChange}/>}
+    </FormCore>)
+
 }

--- a/src/components/fields/edit/TreeViewComponent.jsx
+++ b/src/components/fields/edit/TreeViewComponent.jsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 
-const TreeViewDemo = (props) => {
+const TreeViewComponent = (props) => {
   const {    
     onChange,    
     searchText,
@@ -86,4 +86,4 @@ const TreeViewDemo = (props) => {
   );
 };
 
-export default TreeViewDemo;
+export default TreeViewComponent;

--- a/src/components/fields/edit/TreeViewDemo.jsx
+++ b/src/components/fields/edit/TreeViewDemo.jsx
@@ -80,78 +80,12 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 
-// const renderTree = (nodes, searchText) => {
-//   if (searchText && !nodes.name.toLowerCase().includes(searchText.toLowerCase())) {
-//     return null;
-//   }
-//   const matchesSearch = searchText && nodes.name.toLowerCase().includes(searchText.toLowerCase());
-
-
-//   return (
-//     <TreeItem
-//       key={nodes.id}
-//       nodeId={nodes.id}
-//       label={
-//         <div style={{ display: 'flex', alignItems: 'center' }}>
-//           <Radio />
-//           {nodes.name}
-//         </div>
-//       }
-//     >
-//       {/* {Array.isArray(nodes.locationID)
-//         ? nodes.locationID.map((node) => renderTree(node, searchText))
-//         : null} */}
-
-//       {Array.isArray(nodes.locationID) && matchesSearch
-//         ? nodes.locationID.map((node) => renderTree(node, searchText))
-//         : null}
-//     </TreeItem>
-//   );
-// };
-
-// const TreeViewDemo = (props) => {
-//   const {    
-//     onChange,    
-//   } = props;
-//   const classes = useStyles();
-//   const [searchText, setSearchText] = useState('');
-//   const handleSearchChange = (event) => {
-//     setSearchText(event.target.value);
-//   };
-
-//   const handleNodeSelect = (event, nodeId) => {
-//     console.log('selected', nodeId);
-//     onChange(nodeId);
-//   };
-
-//   return (
-//     <Paper style={{maxHeight:200, width: '100%', overflow:"auto"}}>
-//       <TextField
-//         style={{ width:'100%' }}
-//         label="Search"
-//         value={searchText}
-//         onChange={handleSearchChange}
-//       />
-//       <TreeView
-//         onNodeSelect={handleNodeSelect}
-
-//         className={classes.root}
-//         defaultCollapseIcon={<ExpandMoreIcon />}
-//         defaultExpandIcon={<ChevronRightIcon />}
-//       >
-//         {data.map((node) => renderTree(node, searchText))}
-//       </TreeView>
-//     </Paper>
-//   );
-// };
-
-const renderTree = (nodes, searchText, expandedNodes, onNodeToggle) => {
+const renderTree = (nodes, searchText) => {
   if (searchText && !nodes.name.toLowerCase().includes(searchText.toLowerCase())) {
     return null;
   }
   const matchesSearch = searchText && nodes.name.toLowerCase().includes(searchText.toLowerCase());
 
-  const isExpanded = expandedNodes.includes(nodes.id);
 
   return (
     <TreeItem
@@ -163,50 +97,31 @@ const renderTree = (nodes, searchText, expandedNodes, onNodeToggle) => {
           {nodes.name}
         </div>
       }
-      onIconClick={() => onNodeToggle(nodes.id)}
-      onLabelClick={() => onNodeToggle(nodes.id)}
-      icon={nodes.locationID && nodes.locationID.length > 0 ? (isExpanded ? <ExpandMoreIcon /> : <ChevronRightIcon />) : null}
     >
-      {Array.isArray(nodes.locationID) && matchesSearch && isExpanded
-        ? nodes.locationID.map((node) => renderTree(node, searchText, expandedNodes, onNodeToggle))
+      {Array.isArray(nodes.locationID)
+        ? nodes.locationID.map((node) => renderTree(node, searchText))
         : null}
     </TreeItem>
   );
 };
 
 const TreeViewDemo = (props) => {
-  // ... (unchanged code)
-
   const {    
-        onChange,    
-      } = props;
-      const classes = useStyles();
-      const [searchText, setSearchText] = useState('');
-      const handleSearchChange = (event) => {
-        setSearchText(event.target.value);
-      };
-    
-      const handleNodeSelect = (event, nodeId) => {
-        console.log('selected', nodeId);
-        onChange(nodeId);
-      };
-    
+    onChange,    
+  } = props;
+  const classes = useStyles();
+  const [searchText, setSearchText] = useState('');
+  const handleSearchChange = (event) => {
+    setSearchText(event.target.value);
+  };
 
-  const [expandedNodes, setExpandedNodes] = useState([]);
-
-  const handleNodeToggle = (nodeId) => {
-    setExpandedNodes((prevExpandedNodes) => {
-      if (prevExpandedNodes.includes(nodeId)) {
-        return prevExpandedNodes.filter((id) => id !== nodeId);
-      } else {
-        return [...prevExpandedNodes, nodeId];
-      }
-    });
+  const handleNodeSelect = (event, nodeId) => {
+    console.log('selected', nodeId);
+    onChange(nodeId);
   };
 
   return (
     <Paper style={{maxHeight:200, width: '100%', overflow:"auto"}}>
-      {/* ... (unchanged code) */}
       <TextField
         style={{ width:'100%' }}
         label="Search"
@@ -215,15 +130,96 @@ const TreeViewDemo = (props) => {
       />
       <TreeView
         onNodeSelect={handleNodeSelect}
+
         className={classes.root}
         defaultCollapseIcon={<ExpandMoreIcon />}
         defaultExpandIcon={<ChevronRightIcon />}
       >
-        {data.map((node) => renderTree(node, searchText, expandedNodes, handleNodeToggle))}
+        {data.map((node) => renderTree(node, searchText))}
       </TreeView>
     </Paper>
   );
 };
+
+// const renderTree = (nodes, searchText, expandedNodes, onNodeToggle) => {
+//   if (searchText && !nodes.name.toLowerCase().includes(searchText.toLowerCase())) {
+//     return null;
+//   }
+//   const matchesSearch = searchText && nodes.name.toLowerCase().includes(searchText.toLowerCase());
+
+//   const isExpanded = expandedNodes.includes(nodes.id);
+
+//   return (
+//     <TreeItem
+//       key={nodes.id}
+//       nodeId={nodes.id}
+//       label={
+//         <div style={{ display: 'flex', alignItems: 'center' }}>
+//           <Radio />
+//           {nodes.name}
+//         </div>
+//       }
+//       onIconClick={() => onNodeToggle(nodes.id)}
+//       onLabelClick={() => onNodeToggle(nodes.id)}
+//       icon={nodes.locationID && nodes.locationID.length > 0 ? (isExpanded ? <ExpandMoreIcon /> : <ChevronRightIcon />) : null}
+//     >
+//       {Array.isArray(nodes.locationID) && matchesSearch && isExpanded
+//         ? nodes.locationID.map((node) => renderTree(node, searchText, expandedNodes, onNodeToggle))
+//         : null}
+//     </TreeItem>
+//   );
+// };
+
+// const TreeViewDemo = (props) => {
+//   // ... (unchanged code)
+
+//   const {    
+//         onChange,    
+//       } = props;
+//       const classes = useStyles();
+//       const [searchText, setSearchText] = useState('');
+//       const handleSearchChange = (event) => {
+//         setSearchText(event.target.value);
+//       };
+    
+//       const handleNodeSelect = (event, nodeId) => {
+//         console.log('selected', nodeId);
+//         onChange(nodeId);
+//       };
+    
+
+//   const [expandedNodes, setExpandedNodes] = useState([]);
+
+//   const handleNodeToggle = (nodeId) => {
+//     setExpandedNodes((prevExpandedNodes) => {
+//       if (prevExpandedNodes.includes(nodeId)) {
+//         return prevExpandedNodes.filter((id) => id !== nodeId);
+//       } else {
+//         return [...prevExpandedNodes, nodeId];
+//       }
+//     });
+//   };
+
+//   return (
+//     <Paper style={{maxHeight:200, width: '100%', overflow:"auto"}}>
+//       {/* ... (unchanged code) */}
+//       <TextField
+//         style={{ width:'100%' }}
+//         label="Search"
+//         value={searchText}
+//         onChange={handleSearchChange}
+//       />
+//       <TreeView
+//         onNodeSelect={handleNodeSelect}
+//         className={classes.root}
+//         defaultCollapseIcon={<ExpandMoreIcon />}
+//         defaultExpandIcon={<ChevronRightIcon />}
+//       >
+//         {data.map((node) => renderTree(node, searchText, expandedNodes, handleNodeToggle))}
+//       </TreeView>
+//     </Paper>
+//   );
+// };
 
 
 export default TreeViewDemo;

--- a/src/components/fields/edit/TreeViewDemo.jsx
+++ b/src/components/fields/edit/TreeViewDemo.jsx
@@ -1,0 +1,229 @@
+import React, { useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import TreeView from '@material-ui/lab/TreeView';
+import TreeItem from '@material-ui/lab/TreeItem';
+import TextField from '@material-ui/core/TextField';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import Radio from '@material-ui/core/Radio';
+import Paper from '@material-ui/core/Paper';
+
+
+const data = 
+
+[
+    {
+        "id": "d6ae1777-b03a-45cd-8cf9-216ed30de263",
+        "name": "only"
+    },
+    {
+        "id": "e955e661-cda0-4115-ab45-fab9b85c32fb",
+        "name": "Asia",
+        "locationID": [
+            {
+                "id": "829c5726-a4fe-4029-baea-ad25cf652579",
+                "name": "ITEM2"
+            },
+            {
+                "id": "e2b3b422-8ca9-45a7-b3e6-fe1d37b761bd",
+                "name": "ITEM1"
+            }
+        ]
+    },
+    {
+        "id": "abea08f3-6855-4dff-a872-4593faddbc35",
+        "name": "Africa",
+        "locationID": [
+            {
+                "id": "5030f593-bbbb-448c-a049-ed7012d55edb",
+                "name": "sub4",
+                "locationID": [
+                    {
+                        "id": "aa5ce705-3a39-4d30-83d3-89e6f200696d",
+                        "name": "sub5"
+                    }
+                ]
+            },
+            {
+                "id": "72a4fa59-b53c-4346-af37-8bae0f8991ff",
+                "name": "sub2",
+                "locationID": [
+                    {
+                        "id": "d8f6ac7d-1eca-40e2-817c-12c6be68c41c",
+                        "name": "sub3"
+                    }
+                ]
+            },
+            {
+                "id": "739452af-d1db-43ad-a57f-89293f39fa15",
+                "name": "sub1"
+            }
+        ]
+    }
+];
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    height: 240,
+    flexGrow: 1,
+    maxWidth: 400,
+  },
+  radio: {
+    marginRight: theme.spacing(1),
+    fontSize: '0.8rem',
+  },
+  endIcon: {
+    width: 24,
+    display: 'flex',
+    justifyContent: 'flex-end',
+  },
+}));
+
+
+// const renderTree = (nodes, searchText) => {
+//   if (searchText && !nodes.name.toLowerCase().includes(searchText.toLowerCase())) {
+//     return null;
+//   }
+//   const matchesSearch = searchText && nodes.name.toLowerCase().includes(searchText.toLowerCase());
+
+
+//   return (
+//     <TreeItem
+//       key={nodes.id}
+//       nodeId={nodes.id}
+//       label={
+//         <div style={{ display: 'flex', alignItems: 'center' }}>
+//           <Radio />
+//           {nodes.name}
+//         </div>
+//       }
+//     >
+//       {/* {Array.isArray(nodes.locationID)
+//         ? nodes.locationID.map((node) => renderTree(node, searchText))
+//         : null} */}
+
+//       {Array.isArray(nodes.locationID) && matchesSearch
+//         ? nodes.locationID.map((node) => renderTree(node, searchText))
+//         : null}
+//     </TreeItem>
+//   );
+// };
+
+// const TreeViewDemo = (props) => {
+//   const {    
+//     onChange,    
+//   } = props;
+//   const classes = useStyles();
+//   const [searchText, setSearchText] = useState('');
+//   const handleSearchChange = (event) => {
+//     setSearchText(event.target.value);
+//   };
+
+//   const handleNodeSelect = (event, nodeId) => {
+//     console.log('selected', nodeId);
+//     onChange(nodeId);
+//   };
+
+//   return (
+//     <Paper style={{maxHeight:200, width: '100%', overflow:"auto"}}>
+//       <TextField
+//         style={{ width:'100%' }}
+//         label="Search"
+//         value={searchText}
+//         onChange={handleSearchChange}
+//       />
+//       <TreeView
+//         onNodeSelect={handleNodeSelect}
+
+//         className={classes.root}
+//         defaultCollapseIcon={<ExpandMoreIcon />}
+//         defaultExpandIcon={<ChevronRightIcon />}
+//       >
+//         {data.map((node) => renderTree(node, searchText))}
+//       </TreeView>
+//     </Paper>
+//   );
+// };
+
+const renderTree = (nodes, searchText, expandedNodes, onNodeToggle) => {
+  if (searchText && !nodes.name.toLowerCase().includes(searchText.toLowerCase())) {
+    return null;
+  }
+  const matchesSearch = searchText && nodes.name.toLowerCase().includes(searchText.toLowerCase());
+
+  const isExpanded = expandedNodes.includes(nodes.id);
+
+  return (
+    <TreeItem
+      key={nodes.id}
+      nodeId={nodes.id}
+      label={
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <Radio />
+          {nodes.name}
+        </div>
+      }
+      onIconClick={() => onNodeToggle(nodes.id)}
+      onLabelClick={() => onNodeToggle(nodes.id)}
+      icon={nodes.locationID && nodes.locationID.length > 0 ? (isExpanded ? <ExpandMoreIcon /> : <ChevronRightIcon />) : null}
+    >
+      {Array.isArray(nodes.locationID) && matchesSearch && isExpanded
+        ? nodes.locationID.map((node) => renderTree(node, searchText, expandedNodes, onNodeToggle))
+        : null}
+    </TreeItem>
+  );
+};
+
+const TreeViewDemo = (props) => {
+  // ... (unchanged code)
+
+  const {    
+        onChange,    
+      } = props;
+      const classes = useStyles();
+      const [searchText, setSearchText] = useState('');
+      const handleSearchChange = (event) => {
+        setSearchText(event.target.value);
+      };
+    
+      const handleNodeSelect = (event, nodeId) => {
+        console.log('selected', nodeId);
+        onChange(nodeId);
+      };
+    
+
+  const [expandedNodes, setExpandedNodes] = useState([]);
+
+  const handleNodeToggle = (nodeId) => {
+    setExpandedNodes((prevExpandedNodes) => {
+      if (prevExpandedNodes.includes(nodeId)) {
+        return prevExpandedNodes.filter((id) => id !== nodeId);
+      } else {
+        return [...prevExpandedNodes, nodeId];
+      }
+    });
+  };
+
+  return (
+    <Paper style={{maxHeight:200, width: '100%', overflow:"auto"}}>
+      {/* ... (unchanged code) */}
+      <TextField
+        style={{ width:'100%' }}
+        label="Search"
+        value={searchText}
+        onChange={handleSearchChange}
+      />
+      <TreeView
+        onNodeSelect={handleNodeSelect}
+        className={classes.root}
+        defaultCollapseIcon={<ExpandMoreIcon />}
+        defaultExpandIcon={<ChevronRightIcon />}
+      >
+        {data.map((node) => renderTree(node, searchText, expandedNodes, handleNodeToggle))}
+      </TreeView>
+    </Paper>
+  );
+};
+
+
+export default TreeViewDemo;

--- a/src/components/fields/edit/TreeViewDemo.jsx
+++ b/src/components/fields/edit/TreeViewDemo.jsx
@@ -2,65 +2,12 @@ import React, { useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
 import TreeItem from '@material-ui/lab/TreeItem';
-import TextField from '@material-ui/core/TextField';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import Radio from '@material-ui/core/Radio';
 import Paper from '@material-ui/core/Paper';
+import _ from 'lodash-es';
 
-
-const data = 
-
-[
-    {
-        "id": "d6ae1777-b03a-45cd-8cf9-216ed30de263",
-        "name": "only"
-    },
-    {
-        "id": "e955e661-cda0-4115-ab45-fab9b85c32fb",
-        "name": "Asia",
-        "locationID": [
-            {
-                "id": "829c5726-a4fe-4029-baea-ad25cf652579",
-                "name": "ITEM2"
-            },
-            {
-                "id": "e2b3b422-8ca9-45a7-b3e6-fe1d37b761bd",
-                "name": "ITEM1"
-            }
-        ]
-    },
-    {
-        "id": "abea08f3-6855-4dff-a872-4593faddbc35",
-        "name": "Africa",
-        "locationID": [
-            {
-                "id": "5030f593-bbbb-448c-a049-ed7012d55edb",
-                "name": "sub4",
-                "locationID": [
-                    {
-                        "id": "aa5ce705-3a39-4d30-83d3-89e6f200696d",
-                        "name": "sub5"
-                    }
-                ]
-            },
-            {
-                "id": "72a4fa59-b53c-4346-af37-8bae0f8991ff",
-                "name": "sub2",
-                "locationID": [
-                    {
-                        "id": "d8f6ac7d-1eca-40e2-817c-12c6be68c41c",
-                        "name": "sub3"
-                    }
-                ]
-            },
-            {
-                "id": "739452af-d1db-43ad-a57f-89293f39fa15",
-                "name": "sub1"
-            }
-        ]
-    }
-];
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -80,54 +27,46 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 
-const renderTree = (nodes, searchText) => {
-  if (searchText && !nodes.name.toLowerCase().includes(searchText.toLowerCase())) {
-    return null;
-  }
-  const matchesSearch = searchText && nodes.name.toLowerCase().includes(searchText.toLowerCase());
-
-
-  return (
-    <TreeItem
-      key={nodes.id}
-      nodeId={nodes.id}
-      label={
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          <Radio />
-          {nodes.name}
-        </div>
-      }
-    >
-      {Array.isArray(nodes.locationID)
-        ? nodes.locationID.map((node) => renderTree(node, searchText))
-        : null}
-    </TreeItem>
-  );
-};
-
 const TreeViewDemo = (props) => {
   const {    
     onChange,    
+    searchText,
+    showData
   } = props;
   const classes = useStyles();
-  const [searchText, setSearchText] = useState('');
-  const handleSearchChange = (event) => {
-    setSearchText(event.target.value);
-  };
+  const [selected, setSelected] = useState(null);
 
   const handleNodeSelect = (event, nodeId) => {
-    console.log('selected', nodeId);
     onChange(nodeId);
+    setSelected(nodeId);
   };
 
+  const renderItem = (node) => {
+    return (
+      <TreeItem
+        key={node.id}
+        nodeId={node.id}
+        label={
+          <div style={{ 
+            width: '100%', 
+            display: 'flex', 
+            alignItems: 'center',
+            }}>
+            <Radio checked={selected===node.id}/>
+            {node.name}            
+          </div>
+        }
+      >
+        {Array.isArray(node.locationID)
+          ? node.locationID.map((node) => renderItem(node, searchText))
+          : null}
+      </TreeItem>
+    )
+  }
+
+
   return (
-    <Paper style={{maxHeight:200, width: '100%', overflow:"auto"}}>
-      <TextField
-        style={{ width:'100%' }}
-        label="Search"
-        value={searchText}
-        onChange={handleSearchChange}
-      />
+    <Paper style={{maxHeight:1200, width: '100%', overflow:"auto"}}>
       <TreeView
         onNodeSelect={handleNodeSelect}
 
@@ -135,91 +74,13 @@ const TreeViewDemo = (props) => {
         defaultCollapseIcon={<ExpandMoreIcon />}
         defaultExpandIcon={<ChevronRightIcon />}
       >
-        {data.map((node) => renderTree(node, searchText))}
+        {/* {data.map((node) => renderTree(node, searchText))} */}
+        {(_.isNil(showData) || !_.isArray(showData) || _.isEmpty(showData)) 
+          ? <></> 
+          : showData.map(node => renderItem(node))}
       </TreeView>
     </Paper>
   );
 };
-
-// const renderTree = (nodes, searchText, expandedNodes, onNodeToggle) => {
-//   if (searchText && !nodes.name.toLowerCase().includes(searchText.toLowerCase())) {
-//     return null;
-//   }
-//   const matchesSearch = searchText && nodes.name.toLowerCase().includes(searchText.toLowerCase());
-
-//   const isExpanded = expandedNodes.includes(nodes.id);
-
-//   return (
-//     <TreeItem
-//       key={nodes.id}
-//       nodeId={nodes.id}
-//       label={
-//         <div style={{ display: 'flex', alignItems: 'center' }}>
-//           <Radio />
-//           {nodes.name}
-//         </div>
-//       }
-//       onIconClick={() => onNodeToggle(nodes.id)}
-//       onLabelClick={() => onNodeToggle(nodes.id)}
-//       icon={nodes.locationID && nodes.locationID.length > 0 ? (isExpanded ? <ExpandMoreIcon /> : <ChevronRightIcon />) : null}
-//     >
-//       {Array.isArray(nodes.locationID) && matchesSearch && isExpanded
-//         ? nodes.locationID.map((node) => renderTree(node, searchText, expandedNodes, onNodeToggle))
-//         : null}
-//     </TreeItem>
-//   );
-// };
-
-// const TreeViewDemo = (props) => {
-//   // ... (unchanged code)
-
-//   const {    
-//         onChange,    
-//       } = props;
-//       const classes = useStyles();
-//       const [searchText, setSearchText] = useState('');
-//       const handleSearchChange = (event) => {
-//         setSearchText(event.target.value);
-//       };
-    
-//       const handleNodeSelect = (event, nodeId) => {
-//         console.log('selected', nodeId);
-//         onChange(nodeId);
-//       };
-    
-
-//   const [expandedNodes, setExpandedNodes] = useState([]);
-
-//   const handleNodeToggle = (nodeId) => {
-//     setExpandedNodes((prevExpandedNodes) => {
-//       if (prevExpandedNodes.includes(nodeId)) {
-//         return prevExpandedNodes.filter((id) => id !== nodeId);
-//       } else {
-//         return [...prevExpandedNodes, nodeId];
-//       }
-//     });
-//   };
-
-//   return (
-//     <Paper style={{maxHeight:200, width: '100%', overflow:"auto"}}>
-//       {/* ... (unchanged code) */}
-//       <TextField
-//         style={{ width:'100%' }}
-//         label="Search"
-//         value={searchText}
-//         onChange={handleSearchChange}
-//       />
-//       <TreeView
-//         onNodeSelect={handleNodeSelect}
-//         className={classes.root}
-//         defaultCollapseIcon={<ExpandMoreIcon />}
-//         defaultExpandIcon={<ChevronRightIcon />}
-//       >
-//         {data.map((node) => renderTree(node, searchText, expandedNodes, handleNodeToggle))}
-//       </TreeView>
-//     </Paper>
-//   );
-// };
-
 
 export default TreeViewDemo;

--- a/src/components/fields/edit/TreeViewDemo.jsx
+++ b/src/components/fields/edit/TreeViewDemo.jsx
@@ -1,11 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
 import TreeItem from '@material-ui/lab/TreeItem';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import Radio from '@material-ui/core/Radio';
-import Paper from '@material-ui/core/Paper';
 import _ from 'lodash-es';
 
 
@@ -31,10 +30,12 @@ const TreeViewDemo = (props) => {
   const {    
     onChange,    
     searchText,
-    showData
+    showData,
+    selected,
+    setSelected,
   } = props;
   const classes = useStyles();
-  const [selected, setSelected] = useState(null);
+  
 
   const handleNodeSelect = (event, nodeId) => {
     onChange(nodeId);
@@ -45,7 +46,7 @@ const TreeViewDemo = (props) => {
     return (
       <TreeItem
         key={node.id}
-        nodeId={node.id}
+        nodeId={node.id}        
         label={
           <div style={{ 
             width: '100%', 
@@ -66,20 +67,22 @@ const TreeViewDemo = (props) => {
 
 
   return (
-    <Paper style={{maxHeight:1200, width: '100%', overflow:"auto"}}>
+    <div 
+      
+      style={{maxHeight:1200, width: '100%', overflow:"auto"}}
+      data-testid="treeViewDemo"
+      >
       <TreeView
         onNodeSelect={handleNodeSelect}
-
         className={classes.root}
         defaultCollapseIcon={<ExpandMoreIcon />}
         defaultExpandIcon={<ChevronRightIcon />}
       >
-        {/* {data.map((node) => renderTree(node, searchText))} */}
         {(_.isNil(showData) || !_.isArray(showData) || _.isEmpty(showData)) 
           ? <></> 
           : showData.map(node => renderItem(node))}
       </TreeView>
-    </Paper>
+    </div>
   );
 };
 


### PR DESCRIPTION
1. remodel region editor, UI looks different
2. now when user reports sighting and select region, the dropdown list is a tree view, we can see all regions and sub regions in tree structure
3. when selecting top level region, its sub regions will be expanded
4. when searching region, all regions includes the search text will be displayed, user can also expand the top region to see its sub regions, even if the sub regions don't match search text
5. this component is also used on "re-run identification" page and "customize identification" page
6. on the two pages above, it is still not multiple selection, but we will run job with the selected region and its sub regions, a previous ticket implemented this feature, not affected by this ticket.